### PR TITLE
fix: fix autocomplete prefix

### DIFF
--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -103,7 +103,7 @@ export default class AutocompleteAdapter {
 
     // We must update the replacement prefix as characters are added and removed
     const cache = this._suggestionCache.get(server)!;
-    const replacementPrefix = request.editor.getTextInBufferRange([cache.originalBufferPoint, request.bufferPosition]);
+    const replacementPrefix = request.editor.getTextInBufferRange([[cache.triggerPoint.row, cache.triggerPoint.column + cache.triggerChar.length], request.bufferPosition]);
     for (const suggestion of suggestions) {
       if (suggestion.customReplacmentPrefix) { // having this property means a custom range was provided
         const len = replacementPrefix.length;

--- a/test/adapters/autocomplete-adapter.test.ts
+++ b/test/adapters/autocomplete-adapter.test.ts
@@ -504,6 +504,27 @@ describe('AutoCompleteAdapter', () => {
       result = (await autoCompleteAdapter.getSuggestions(server, customRequest))[0];
       expect(result.replacementPrefix).equals('ba');
     });
+
+    it('includes non trigger character prefix in replacementPrefix', async () => {
+      const customRequest = createRequest({ prefix: 'foo', position: new Point(0, 3) });
+      customRequest.editor.setText('foo');
+      sinon.stub(server.connection, 'completion').resolves([
+        createCompletionItem('foobar'),
+      ]);
+      let result = (await autoCompleteAdapter.getSuggestions(server, customRequest))[0];
+
+      expect(result.replacementPrefix).equals('foo');
+      customRequest.editor.setTextInBufferRange([[0, 3], [0, 3]], 'b');
+      customRequest.prefix = 'foob';
+      customRequest.bufferPosition = new Point(0, 4);
+      result = (await autoCompleteAdapter.getSuggestions(server, customRequest))[0];
+      expect(result.replacementPrefix).equals('foob');
+      customRequest.editor.setTextInBufferRange([[0, 4], [0, 4]], 'a');
+      customRequest.prefix = 'fooba';
+      customRequest.bufferPosition = new Point(0, 5);
+      result = (await autoCompleteAdapter.getSuggestions(server, customRequest))[0];
+      expect(result.replacementPrefix).equals('fooba');
+    });
   });
 
   describe('completionKindToSuggestionType', () => {


### PR DESCRIPTION
This should work the way it is supposed to. I basically reverted #100 and just removed the trigger char from the `replacementPrefix` and added a test to make sure this continues to work in the future.

fixes #113