### PR TITLE
feat: API for registering custom callbacks for Commands

### DIFF
--- a/lib/adapters/code-action-adapter.ts
+++ b/lib/adapters/code-action-adapter.ts
@@ -15,6 +15,7 @@ import {
   Range,
   TextEditor,
 } from 'atom';
+import CommandExecutionAdapter from './command-execution-adapter';
 
 export default class CodeActionAdapter {
   /**
@@ -88,10 +89,7 @@ export default class CodeActionAdapter {
     connection: LanguageClientConnection,
   ): Promise<void> {
     if (Command.is(command)) {
-      await connection.executeCommand({
-        command: command.command,
-        arguments: command.arguments,
-      });
+      await CommandExecutionAdapter.executeCommand(connection, command.command, command.arguments);
     }
   }
 

--- a/lib/adapters/command-execution-adapter.ts
+++ b/lib/adapters/command-execution-adapter.ts
@@ -4,7 +4,7 @@ import { LanguageClientConnection } from "../main";
 export type CommandCustomCallbackFunction = (command: ExecuteCommandParams) => Promise<any | void>;
 
 export default class CommandExecutionAdapter {
-    private static commandsCustomCallbacks: Map<string, CommandCustomCallbackFunction> = new Map<string, CommandCustomCallbackFunction>();
+    private static commandsCustomCallbacks = new Map<string, CommandCustomCallbackFunction>();
 
     public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
       return serverCapabilities.executeCommandProvider != null;
@@ -14,14 +14,14 @@ export default class CommandExecutionAdapter {
         this.commandsCustomCallbacks.set(command, callback);
     }
 
-    public static async executeCommand(connection: LanguageClientConnection, command: string, commandArgs?: any[] | undefined): Promise<any | void> {
+    public static async executeCommand(connection: LanguageClientConnection, command: string, commandArgs?: any[]): Promise<any | void> {
         const executeCommandParams = CommandExecutionAdapter.createExecuteCommandParams(command, commandArgs);
         const commandCustomCallback = this.commandsCustomCallbacks.get(command);
 
         return commandCustomCallback != null ? await commandCustomCallback(executeCommandParams) : await connection.executeCommand(executeCommandParams);
     }
 
-    private static createExecuteCommandParams(command: string, commandArgs?: any[] | undefined): ExecuteCommandParams {
+    private static createExecuteCommandParams(command: string, commandArgs?: any[]): ExecuteCommandParams {
         return {
             command: command,
             arguments: commandArgs

--- a/lib/adapters/command-execution-adapter.ts
+++ b/lib/adapters/command-execution-adapter.ts
@@ -18,7 +18,7 @@ export default class CommandExecutionAdapter {
         const executeCommandParams = CommandExecutionAdapter.createExecuteCommandParams(command, commandArgs);
         const commandCustomCallback = this.commandsCustomCallbacks.get(command);
 
-        return commandCustomCallback != null ? await commandCustomCallback(executeCommandParams) : await connection.executeCommand(executeCommandParams);
+        return commandCustomCallback !== undefined ? await commandCustomCallback(executeCommandParams) : await connection.executeCommand(executeCommandParams);
     }
 
     private static createExecuteCommandParams(command: string, commandArgs?: any[]): ExecuteCommandParams {

--- a/lib/adapters/command-execution-adapter.ts
+++ b/lib/adapters/command-execution-adapter.ts
@@ -1,10 +1,14 @@
-import { ExecuteCommandParams } from "../languageclient";
+import { ExecuteCommandParams, ServerCapabilities } from "../languageclient";
 import { LanguageClientConnection } from "../main";
 
 export type CommandCustomCallbackFunction = (command: ExecuteCommandParams) => Promise<any | void>;
 
 export default class CommandExecutionAdapter {
     private static commandsCustomCallbacks: Map<string, CommandCustomCallbackFunction> = new Map<string, CommandCustomCallbackFunction>();
+
+    public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
+      return serverCapabilities.executeCommandProvider != null;
+    }
 
     public static registerCustomCallbackForCommand(command: string, callback: CommandCustomCallbackFunction): void {
         this.commandsCustomCallbacks.set(command, callback);

--- a/lib/adapters/command-execution-adapter.ts
+++ b/lib/adapters/command-execution-adapter.ts
@@ -6,7 +6,7 @@ export type CommandCustomCallbackFunction = (command: ExecuteCommandParams) => P
 export default class CommandExecutionAdapter {
     private static commandsCustomCallbacks: Map<string, CommandCustomCallbackFunction> = new Map<string, CommandCustomCallbackFunction>();
 
-    public static registerCustomCallbackForCommand(command: string, callback: CommandCustomCallbackFunction) {
+    public static registerCustomCallbackForCommand(command: string, callback: CommandCustomCallbackFunction): void {
         this.commandsCustomCallbacks.set(command, callback);
     }
 

--- a/lib/adapters/command-execution-adapter.ts
+++ b/lib/adapters/command-execution-adapter.ts
@@ -1,0 +1,26 @@
+import { Command, ExecuteCommandParams } from "../languageclient";
+import { LanguageClientConnection } from "../main";
+
+export type CommandCustomCallbackFunction = (command: ExecuteCommandParams) => Promise<void>;
+
+export default class CommandExecutionAdapter {
+    private static commandsCustomCallbacks: Map<string, CommandCustomCallbackFunction> = new Map<string, CommandCustomCallbackFunction>();
+
+    public static registerCustomCallbackForCommand(command: string, callback: CommandCustomCallbackFunction) {
+        this.commandsCustomCallbacks.set(command, callback);
+    }
+
+    public static async executeCommand(connection: LanguageClientConnection, command: string, commandArgs?: any[] | undefined): Promise<any | void> {
+        const executeCommandParams = CommandExecutionAdapter.createExecuteCommandParams(command, commandArgs);
+        const commandCustomCallback = this.commandsCustomCallbacks.get(command);
+
+        return commandCustomCallback != null ? await commandCustomCallback(executeCommandParams) : await connection.executeCommand(executeCommandParams);
+    }
+
+    public static createExecuteCommandParams(command: string, commandArgs?: any[] | undefined): ExecuteCommandParams {
+        return {
+            command: command,
+            arguments: commandArgs
+        };
+    }
+}

--- a/lib/adapters/command-execution-adapter.ts
+++ b/lib/adapters/command-execution-adapter.ts
@@ -1,7 +1,7 @@
-import { Command, ExecuteCommandParams } from "../languageclient";
+import { ExecuteCommandParams } from "../languageclient";
 import { LanguageClientConnection } from "../main";
 
-export type CommandCustomCallbackFunction = (command: ExecuteCommandParams) => Promise<void>;
+export type CommandCustomCallbackFunction = (command: ExecuteCommandParams) => Promise<any | void>;
 
 export default class CommandExecutionAdapter {
     private static commandsCustomCallbacks: Map<string, CommandCustomCallbackFunction> = new Map<string, CommandCustomCallbackFunction>();
@@ -17,7 +17,7 @@ export default class CommandExecutionAdapter {
         return commandCustomCallback != null ? await commandCustomCallback(executeCommandParams) : await connection.executeCommand(executeCommandParams);
     }
 
-    public static createExecuteCommandParams(command: string, commandArgs?: any[] | undefined): ExecuteCommandParams {
+    private static createExecuteCommandParams(command: string, commandArgs?: any[] | undefined): ExecuteCommandParams {
         return {
             command: command,
             arguments: commandArgs

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -8,6 +8,7 @@ import Convert from './convert';
 import { Logger, ConsoleLogger, FilteredLogger } from './logger';
 import DownloadFile from './download-file';
 import LinterPushV2Adapter from './adapters/linter-push-v2-adapter';
+import CommandExecutionAdapter from './adapters/command-execution-adapter';
 
 export * from './auto-languageclient';
 export {
@@ -18,4 +19,5 @@ export {
   FilteredLogger,
   DownloadFile,
   LinterPushV2Adapter,
+  CommandExecutionAdapter
 };

--- a/test/adapters/command-execution-adapter.test.ts
+++ b/test/adapters/command-execution-adapter.test.ts
@@ -6,6 +6,20 @@ import { createSpyConnection } from '../helpers.js';
 import { ExecuteCommandParams } from '../../lib/languageclient';
 
 describe('CommandExecutionAdapter', () => {
+    describe('canAdapt', () => {
+      it('returns true if command execution is supported', () => {
+        const result = CommandExecutionAdapter.canAdapt({
+          executeCommandProvider: {commands: []},
+        });
+        expect(result).to.be.true;
+      });
+
+      it('returns false it no formatting supported', () => {
+        const result = CommandExecutionAdapter.canAdapt({});
+        expect(result).to.be.false;
+      });
+    });
+
   describe('executeCommand', () => {
     it('invokes an executeCommand object from given inputs', async () => {
       const connection = createSpyConnection();

--- a/test/adapters/command-execution-adapter.test.ts
+++ b/test/adapters/command-execution-adapter.test.ts
@@ -1,0 +1,64 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import * as ls from '../../lib/languageclient';
+import CommandExecutionAdapter, { CommandCustomCallbackFunction } from '../../lib/adapters/command-execution-adapter';
+import { createSpyConnection } from '../helpers.js';
+import { ExecuteCommandParams } from '../../lib/languageclient';
+
+describe('CommandExecutionAdapter', () => {
+  describe('executeCommand', () => {
+    it('invokes an executeCommand object from given inputs', async () => {
+      const connection = createSpyConnection();
+      const languageClient = new ls.LanguageClientConnection(connection);
+      const testCommand = {
+        command: 'testCommand',
+        arguments: ['a', 'b'],
+      };
+      sinon.stub(languageClient, 'executeCommand').returns(Promise.resolve(testCommand));
+
+      const result = await CommandExecutionAdapter.executeCommand(
+        languageClient,
+        testCommand.command,
+        testCommand.arguments
+      );
+
+      expect(result.command).to.equal(testCommand.command);
+      expect(result.arguments).to.equal(testCommand.arguments);
+
+      expect((languageClient as any).executeCommand.called).to.be.true;
+      expect((languageClient as any).executeCommand.getCalls()[0].args).to.deep.equal([{
+          command: testCommand.command,
+          arguments: testCommand.arguments
+      } as ExecuteCommandParams]);
+    });
+  });
+
+  describe('registerCustomCallbackForCommand', () => {
+    it('registers a custom callback for a command, to be executed on executeCommand', async () => {
+      const connection = createSpyConnection();
+      const languageClient = new ls.LanguageClientConnection(connection);
+      const testCallback: CommandCustomCallbackFunction = (command: ExecuteCommandParams) => Promise.resolve(command.command);
+      const testCommand = {
+        command: 'testCommand',
+        arguments: ['a', 'b'],
+      };
+
+      const spiedCallback = sinon.spy(testCallback);
+      sinon.spy(languageClient, 'executeCommand');
+
+      CommandExecutionAdapter.registerCustomCallbackForCommand(testCommand.command, spiedCallback);
+
+      const result = await CommandExecutionAdapter.executeCommand(
+        languageClient,
+        testCommand.command,
+        testCommand.arguments
+      );
+
+      expect(spiedCallback.called).to.be.true;
+
+      expect((languageClient as any).executeCommand.called).to.be.false;
+
+      expect(result).to.equal(testCommand.command);
+    });
+  });
+});


### PR DESCRIPTION
Followup to #12 , discussions made there and [there](https://github.com/atom/atom-languageclient/issues/183).

A developer can register a callback that happens when an `executeCommand` is fired for `DoBlaBlaJavaThingyTypeBeat`. If a command was not registered with a callback by the developer - let that `Command` reach the server. Otherwise - fire the callback that was registered by the developer.

This brings package developers full control as to how `Command`s are executed "globally".
i.e - they can register a command and a callback for it, and have parts of their package (like code actions, or other custom areas) call those `Command`s and have them executed just like VSCode does today. But, this will probably be mainly needed/used for code actions, [where the standard isn't explicit with `Command`s are executed](https://github.com/microsoft/language-server-protocol/issues/430).

I could also use some help testing this with ide-java as I'm not used to building and debugging extensions. I can do this myself but if anyone can easily test this let me know.

@UziTech 