### PR TITLE
fix: fix type errors when atom-languageclient is used with TypeScript

### DIFF
--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -20,7 +20,7 @@ import {
   TextEditor,
 } from 'atom';
 import * as ac from 'atom/autocomplete-plus';
-import { Suggestion, TextSuggestion, SnippetSuggestion } from 'atom-ide';
+import { Suggestion, TextSuggestion, SnippetSuggestion } from '../types/autocomplete-extended';
 
 /**
  * Holds a list of suggestions generated from the CompletionItem[]

--- a/lib/types/autocomplete-extended.ts
+++ b/lib/types/autocomplete-extended.ts
@@ -1,0 +1,25 @@
+// Autocomplete extention (the properties added by atom-languageclient)
+// See this PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51284
+
+import * as ac from 'atom/autocomplete-plus';
+
+/** Adds LSP specific properties to the Atom SuggestionBase type */
+interface SuggestionBase extends ac.SuggestionBase {
+  /**
+   * A string that is used when filtering and sorting a set of
+   * completion items with a prefix present. When `falsy` the
+   * [displayText](#ac.SuggestionBase.displayText) is used. When
+   * no prefix, the `sortText` property is used.
+   */
+  filterText?: string;
+
+  /**
+   * String representing the replacement prefix from the suggestion's
+   * custom start point to the original buffer position the suggestion
+   * was gathered from.
+   */
+  customReplacmentPrefix?: string;
+}
+export type TextSuggestion = SuggestionBase & ac.TextSuggestion;
+export type SnippetSuggestion = SuggestionBase & ac.SnippetSuggestion;
+export type Suggestion =  TextSuggestion | SnippetSuggestion;

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "test.format": "prettier . --check",
     "lint": "eslint . --fix --ext .ts",
     "test.lint": "eslint . --ext .ts",
-    "clean": "rimraf build",
-    "compile": "tsc",
-    "watch": "tsc -watch",
+    "clean": "shx rm -rf build && mkdirp build",
+    "copy.typings": "shx cp -r ./typings ./build",
+    "compile": "npm run copy.typings && tsc",
+    "watch": "npm run compile -- --watch",
     "prepare": "npm run clean && npm run compile",
     "test": "npm run compile && atom --test build/test"
   },
@@ -43,7 +44,7 @@
     "eslint": "^7.18.0",
     "mocha": "^8.2.1",
     "mocha-appveyor-reporter": "^0.4.2",
-    "rimraf": "^3.0.2",
+    "shx": "^0.3.3",
     "sinon": "^9.2.4",
     "typescript": "~4.1.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ devDependencies:
   eslint: 7.18.0
   mocha: 8.2.1
   mocha-appveyor-reporter: 0.4.2
-  rimraf: 3.0.2
+  shx: 0.3.3
   sinon: 9.2.4
   typescript: 4.1.3
 lockfileVersion: 5.2
@@ -996,6 +996,10 @@ packages:
       - darwin
     resolution:
       integrity: sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+  /function-bind/1.1.1:
+    dev: true
+    resolution:
+      integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
   /functional-red-black-tree/1.0.1:
     dev: true
     resolution:
@@ -1100,6 +1104,14 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+  /has/1.0.3:
+    dependencies:
+      function-bind: 1.1.1
+    dev: true
+    engines:
+      node: '>= 0.4.0'
+    resolution:
+      integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   /he/1.2.0:
     dev: true
     hasBin: true
@@ -1162,6 +1174,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+  /interpret/1.4.0:
+    dev: true
+    engines:
+      node: '>= 0.10'
+    resolution:
+      integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
   /is-binary-path/2.1.0:
     dependencies:
       binary-extensions: 2.2.0
@@ -1170,6 +1188,12 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  /is-core-module/2.2.0:
+    dependencies:
+      has: 1.0.3
+    dev: true
+    resolution:
+      integrity: sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
   /is-extglob/2.1.1:
     dev: true
     engines:
@@ -1616,6 +1640,10 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+  /path-parse/1.0.6:
+    dev: true
+    resolution:
+      integrity: sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
   /path-to-regexp/1.8.0:
     dependencies:
       isarray: 0.0.1
@@ -1720,6 +1748,14 @@ packages:
       node: '>=8.10.0'
     resolution:
       integrity: sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
+  /rechoir/0.6.2:
+    dependencies:
+      resolve: 1.20.0
+    dev: true
+    engines:
+      node: '>= 0.10'
+    resolution:
+      integrity: sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
   /regexpp/3.1.0:
     dev: true
     engines:
@@ -1783,6 +1819,13 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+  /resolve/1.20.0:
+    dependencies:
+      is-core-module: 2.2.0
+      path-parse: 1.0.6
+    dev: true
+    resolution:
+      integrity: sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
   /reusify/1.0.4:
     dev: true
     engines:
@@ -1870,6 +1913,27 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+  /shelljs/0.8.4:
+    dependencies:
+      glob: 7.1.6
+      interpret: 1.4.0
+      rechoir: 0.6.2
+    dev: true
+    engines:
+      node: '>=4'
+    hasBin: true
+    resolution:
+      integrity: sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
+  /shx/0.3.3:
+    dependencies:
+      minimist: 1.2.5
+      shelljs: 0.8.4
+    dev: true
+    engines:
+      node: '>=6'
+    hasBin: true
+    resolution:
+      integrity: sha512-nZJ3HFWVoTSyyB+evEKjJ1STiixGztlqwKLTUNV5KqMWtGey9fTd4KU1gdZ1X9BV6215pswQ/Jew9NsuS/fNDA==
   /sinon/9.2.4:
     dependencies:
       '@sinonjs/commons': 1.8.2
@@ -2255,7 +2319,7 @@ specifiers:
   eslint: ^7.18.0
   mocha: ^8.2.1
   mocha-appveyor-reporter: ^0.4.2
-  rimraf: ^3.0.2
+  shx: ^0.3.3
   sinon: ^9.2.4
   typescript: ~4.1.3
   vscode-jsonrpc: 5.0.1

--- a/test/adapters/autocomplete-adapter.test.ts
+++ b/test/adapters/autocomplete-adapter.test.ts
@@ -9,7 +9,7 @@ import {
 import * as ac from 'atom/autocomplete-plus';
 import { expect } from 'chai';
 import { createSpyConnection, createFakeEditor } from '../helpers.js';
-import { TextSuggestion, SnippetSuggestion } from 'atom-ide';
+import { TextSuggestion, SnippetSuggestion } from '../../lib/types/autocomplete-extended';
 import { CompletionItem, MarkupContent, InsertTextFormat, TextEdit, Command } from '../../lib/languageclient';
 
 function createRequest({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,8 @@
         ]
     },
     "include": [
-        "typings/**/*.ts",
-        "lib/**/*.ts",
-        "test/**/*.ts"
+        "typings",
+        "lib",
+        "test"
     ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,11 @@
         "noFallthroughCasesInSwitch": true,
         "noImplicitReturns": true,
         "noUnusedLocals": true,
-        "baseUrl": "./"
+        "baseUrl": "./",
+        "typeRoots": [
+            "./node_modules/@types",
+            "./typings"
+        ]
     },
     "include": [
         "typings/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
         "noFallthroughCasesInSwitch": true,
         "noImplicitReturns": true,
         "noUnusedLocals": true,
-        "baseUrl": "./",
         "typeRoots": [
             "./node_modules/@types",
             "./typings"

--- a/typings/atom-ide/index.d.ts
+++ b/typings/atom-ide/index.d.ts
@@ -1,36 +1,4 @@
 declare module 'atom-ide' {
-
   // atom-ide-base types for backward compatibility
   export * from "atom-ide-base/types-packages/main"
-
-  // NotificationButton for backward compatibility (moved to "../../lib/adapters/notifications-adapter")
-  export interface NotificationButton {
-    text: string
-  }
-
-  // Autocomplete extention (the properties added by atom-languageclient)
-  // See this PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51284
-
-  import * as ac from 'atom/autocomplete-plus';
-
-  /** Adds LSP specific properties to the Atom SuggestionBase type */
-  interface SuggestionBase extends ac.SuggestionBase {
-    /**
-     * A string that is used when filtering and sorting a set of
-     * completion items with a prefix present. When `falsy` the
-     * [displayText](#ac.SuggestionBase.displayText) is used. When
-     * no prefix, the `sortText` property is used.
-     */
-    filterText?: string;
-
-    /**
-     * String representing the replacement prefix from the suggestion's
-     * custom start point to the original buffer position the suggestion
-     * was gathered from.
-     */
-    customReplacmentPrefix?: string;
-  }
-  export type TextSuggestion = SuggestionBase & ac.TextSuggestion;
-  export type SnippetSuggestion = SuggestionBase & ac.SnippetSuggestion;
-  export type Suggestion =  TextSuggestion | SnippetSuggestion;
 }


### PR DESCRIPTION
This fixes the type errors when atom-languageclient is used with TypeScript.

### Verification

With this PR, the following client does not error anymore: 
https://github.com/Pure-D/atomize-d/pull/34