### PR TITLE
feat: add functions for spawning a general executable + allow custom handlers for lsProcess + fix LanguageServerProcess type

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Note that you will also need to add various entries to the `providedServices` an
 
 ### Minimal example (General LSP exe)
 
-If the LSP is a general executable (not a JavaScript file), you should use `spawn` inside `startServerProcess`. `getExePath` is a cross-platform utility function to get the exe path for the given exe name (under the `bin/platform-arch/exeName` by default).
+If the LSP is a general executable (not a JavaScript file), you should use `spawn` inside `startServerProcess`. `getExePath` is a cross-platform utility function to get the exe path for the given exe name (under the `bin/platform-arch/exeName` by default or `exeName` if the file doesn't exist).
 
 ```javascript
 const {AutoLanguageClient, getExePath} = require('atom-languageclient')

--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ Note that you will also need to add various entries to the `providedServices` an
 
 ### Minimal example (General LSP exe)
 
-If the LSP is a general executable (not a JavaScript file), you should use `spawn` inside `startServerProcess`. `getExePath` is a cross-platform utility function to get the exe path for the given exe name (under the `bin/platform-arch/exeName` by default or `exeName` if the file doesn't exist).
+If the LSP is a general executable (not a JavaScript file), you should use `spawn` inside `startServerProcess`.
 
 ```javascript
-const {AutoLanguageClient, getExePath} = require('atom-languageclient')
+const {AutoLanguageClient} = require('atom-languageclient')
 
 class DLanguageClient extends AutoLanguageClient {
   getGrammarScopes () { return [ 'source.d' ] }
@@ -97,7 +97,8 @@ class DLanguageClient extends AutoLanguageClient {
 
   startServerProcess (projectPath) {
     return super.spawn(
-      getExePath('serve-d'),    // path to the LSP executable (or the exe name if it is on the PATH)
+      'serve-d',                // the `name` or `path` of the executable
+                                // if the `name` is provided it checks `bin/platform-arch/exeName` by default, and if doesn't exists uses the `exeName` on the PATH
       [],                       // args passed to spawn the exe
       { cwd: projectPath }      // child process spawn options
     )

--- a/README.md
+++ b/README.md
@@ -85,9 +85,7 @@ Note that you will also need to add various entries to the `providedServices` an
 
 ### Minimal example (General LSP exe)
 
-If the LSP is a general executable (not a JavaScript file), you should use `spawn` inside `startServerProcess`.
-
-`getExePath` is a cross-platform utility function to get the exe path for the given exe name (under the `bin` folder by default).
+If the LSP is a general executable (not a JavaScript file), you should use `spawn` inside `startServerProcess`. `getExePath` is a cross-platform utility function to get the exe path for the given exe name (under the `bin/platform-arch/exeName` by default).
 
 ```javascript
 const {AutoLanguageClient, getExePath} = require('atom-languageclient')

--- a/README.md
+++ b/README.md
@@ -87,9 +87,10 @@ Note that you will also need to add various entries to the `providedServices` an
 
 If the LSP is a general executable (not a JavaScript file), you should use `spawn` inside `startServerProcess`.
 
+`getExePath` is a cross-platform utility function to get the exe path for the given exe name (under the `bin` folder by default).
+
 ```javascript
-const {AutoLanguageClient} = require('atom-languageclient')
-const {resolve} = require('path')
+const {AutoLanguageClient, getExePath} = require('atom-languageclient')
 
 class DLanguageClient extends AutoLanguageClient {
   getGrammarScopes () { return [ 'source.d' ] }
@@ -98,8 +99,8 @@ class DLanguageClient extends AutoLanguageClient {
 
   startServerProcess (projectPath) {
     return super.spawn(
-      resolve('./bin/serve-d'), // path to the LSP executable
-      [],                       // args used for spawning
+      getExePath('serve-d'),    // path to the LSP executable.
+      [],                       // args passed to spawn the exe
       { cwd: projectPath }      // child process spawn options
     )
   }

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Provide integration support for adding Language Server Protocol servers to Atom.
 This npm package can be used by Atom package authors wanting to integrate LSP-compatible language servers with Atom. It provides:
 
 * Conversion routines between Atom and LSP types
-* A FlowTyped wrapper around JSON-RPC for **v3** of the LSP protocol
-* All necessary FlowTyped input and return structures for LSP, notifications etc.
+* A TypeScript wrapper around JSON-RPC for **v3** of the LSP protocol
+* All necessary TypeScript input and return structures for LSP, notifications etc.
 * A number of adapters to translate communication between Atom/Atom-IDE and the LSP's capabilities
 * Automatic wiring up of adapters based on the negotiated capabilities of the language server
 * Helper functions for downloading additional non-npm dependencies
@@ -59,9 +59,9 @@ The language server protocol consists of a number of capabilities. Some of these
 
 The underlying JSON-RPC communication is handled by the [vscode-jsonrpc npm module](https://www.npmjs.com/package/vscode-jsonrpc).
 
-### Minimal example
+### Minimal example (Nodejs-compatible LSP exe)
 
-A minimal implementation can be illustrated by the Omnisharp package here which has only npm-managed dependencies.  You simply provide the scope name, language name and server name as well as start your process and AutoLanguageClient takes care of interrogating your language server capabilities and wiring up the appropriate services within Atom to expose them.
+A minimal implementation can be illustrated by the Omnisharp package here which has only npm-managed dependencies, and the LSP is a JavaScript file.  You simply provide the scope name, language name and server name as well as start your process and `AutoLanguageClient` takes care of interrogating your language server capabilities and wiring up the appropriate services within Atom to expose them.
 
 ```javascript
 const {AutoLanguageClient} = require('atom-languageclient')
@@ -82,6 +82,32 @@ module.exports = new CSharpLanguageClient()
 You can get this code packaged up with the necessary package.json etc. from the [ide-csharp](https://github.com/atom/ide-csharp) provides C# support via [Omnisharp (node-omnisharp)](https://github.com/OmniSharp/omnisharp-node-client) repo.
 
 Note that you will also need to add various entries to the `providedServices` and `consumedServices` section of your package.json (for now).  You can [obtain these entries here](https://github.com/atom/ide-csharp/tree/master/package.json).
+
+### Minimal example (General LSP exe)
+
+If the LSP is a general executable (not a JavaScript file), you should use `spawn` inside `startServerProcess`.
+
+```javascript
+const {AutoLanguageClient} = require('atom-languageclient')
+const {resolve} = require('path')
+
+class DLanguageClient extends AutoLanguageClient {
+  getGrammarScopes () { return [ 'source.d' ] }
+  getLanguageName () { return 'D' }
+  getServerName () { return 'serve-d' }
+
+  startServerProcess (projectPath) {
+    return super.spawn(
+      resolve('./bin/serve-d'), // path to the LSP executable
+      [],                       // args used for spawning
+      { cwd: projectPath }      // child process spawn options
+    )
+  }
+}
+
+module.exports = new DLanguageClient()
+```
+
 
 ### Using other connection types
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ class DLanguageClient extends AutoLanguageClient {
 
   startServerProcess (projectPath) {
     return super.spawn(
-      getExePath('serve-d'),    // path to the LSP executable.
+      getExePath('serve-d'),    // path to the LSP executable (or the exe name if it is on the PATH)
       [],                       // args passed to spawn the exe
       { cwd: projectPath }      // child process spawn options
     )

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -383,6 +383,7 @@ export default class AutoLanguageClient {
   private captureServerErrors(lsProcess: LanguageServerProcess, projectPath: string): void {
     lsProcess.on('error', (err) => this.onSpawnError(err));
     lsProcess.on("close", (code, signal) => this.onSpawnClose(code, signal));
+    lsProcess.on("disconnect", () => this.onSpawnDisconnect());
     lsProcess.on('exit', (code, signal) => this.onSpawnExit(code, signal));
     lsProcess.stderr?.setEncoding('utf8');
     lsProcess.stderr?.on('data', (chunk: Buffer) => this.onSpawnStdErrData(chunk, projectPath));
@@ -412,6 +413,12 @@ export default class AutoLanguageClient {
     }
   }
 
+  /** The function called whenever the spawned server `disconnect`s.
+   *  Extend (call super.onSpawnDisconnect) or override this if you need custom disconnect handling
+   */
+  protected onSpawnDisconnect(): void {
+    this.logger.debug(`${this.getServerName()} language server for ${this.getLanguageName()} got disconnected.`);
+  }
 
   /** The function called whenever the spawned server `exit`s.
    *  Extend (call super.onSpawnExit) or override this if you need custom exit handling

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -279,6 +279,19 @@ export default class AutoLanguageClient {
     await this._serverManager.stopAllServers();
   }
 
+  /** Spawn a general language server
+   *  Use this inside the `startServerProcess` override if the language server is a general executable
+   *  Also see the `spawnChildNode` method
+   */
+  protected spawn(lspPath: string, args: string[], options: cp.SpawnOptions = {}): cp.ChildProcess {
+    this.logger.debug(`starting "${lspPath} ${args.join(' ')}"`);
+    return cp.spawn(lspPath, args, options);
+  }
+
+  /** Spawn a language server using Atom's Nodejs process
+   *  Use this inside the `startServerProcess` override if the language server is a JavaScript file.
+   *  Also see the `spawn` method
+   */
   protected spawnChildNode(args: string[], options: cp.SpawnOptions = {}): cp.ChildProcess {
     this.logger.debug(`starting child Node "${args.join(' ')}"`);
     options.env = options.env || Object.create(process.env);

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -283,9 +283,9 @@ export default class AutoLanguageClient {
    *  Use this inside the `startServerProcess` override if the language server is a general executable
    *  Also see the `spawnChildNode` method
    */
-  protected spawn(lspPath: string, args: string[], options: cp.SpawnOptions = {}): cp.ChildProcess {
-    this.logger.debug(`starting "${lspPath} ${args.join(' ')}"`);
-    return cp.spawn(lspPath, args, options);
+  protected spawn(exe: string, args: string[], options: cp.SpawnOptions = {}): cp.ChildProcess {
+    this.logger.debug(`starting "${exe} ${args.join(' ')}"`);
+    return cp.spawn(exe, args, options);
   }
 
   /** Spawn a language server using Atom's Nodejs process

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -279,13 +279,27 @@ export default class AutoLanguageClient {
     await this._serverManager.stopAllServers();
   }
 
-  /** Spawn a general language server
-   *  Use this inside the `startServerProcess` override if the language server is a general executable
-   *  Also see the `spawnChildNode` method
+  /**
+   * Spawn a general language server.
+   * Use this inside the `startServerProcess` override if the language server is a general executable.
+   * Also see the `spawnChildNode` method.
+   * If the name is provided as the first argument, it checks `bin/platform-arch/exeName` by default, and if doesn't exists uses the exe on PATH.
+   * For example on Windows x64, by passing `serve-d`, `bin/win32-x64/exeName.exe` is spawned by default.
+   * @param exe the `name` or `path` of the executable
+   * @param args args passed to spawn the exe. Defaults to `[]`.
+   * @param options: child process spawn options. Defaults to `{}`.
+   * @param rootPath the path of the folder of the exe file. Defaults to `join("bin", `${process.platform}-${process.arch}`)`.
+   * @param exeExtention the extention of the exe file. Defaults to `process.platform === "win32" ? ".exe" : ""`
    */
-  protected spawn(exe: string, args: string[], options: cp.SpawnOptions = {}): LanguageServerProcess {
+  protected spawn(
+    exe: string,
+    args: string[] = [],
+    options: cp.SpawnOptions = {},
+    rootPath = Utils.rootPathDefault,
+    exeExtention = Utils.exeExtentionDefault
+  ): LanguageServerProcess {
     this.logger.debug(`starting "${exe} ${args.join(' ')}"`);
-    return cp.spawn(exe, args, options);
+    return cp.spawn(Utils.getExePath(exe, rootPath, exeExtention), args, options);
   }
 
   /** Spawn a language server using Atom's Nodejs process

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -368,6 +368,7 @@ export default class AutoLanguageClient {
 
   private captureServerErrors(lsProcess: LanguageServerProcess, projectPath: string): void {
     lsProcess.on('error', (err) => this.handleSpawnFailure(err));
+    lsProcess.on("close", (...args) => this.handleCloseFailure(...args));
     lsProcess.on('exit', (code, signal) => this.logger.debug(`exit: code ${code} signal ${signal}`));
     lsProcess.stderr.setEncoding('utf8');
     lsProcess.stderr.on('data', (chunk: Buffer) => {
@@ -389,6 +390,14 @@ export default class AutoLanguageClient {
         description: err.toString(),
       },
     );
+  }
+
+  private handleCloseFailure(code: number | null, signal: NodeJS.Signals | null): void {
+    if (code !== 0 && signal === null) {
+      atom.notifications.addError(
+        `${this.getServerName()} language server for ${this.getLanguageName()} was closed with code: ${code}.`
+      );
+    }
   }
 
   /** Creates the RPC connection which can be ipc, socket or stdio */

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -9,6 +9,7 @@ import { Logger, ConsoleLogger, FilteredLogger } from './logger';
 import DownloadFile from './download-file';
 import LinterPushV2Adapter from './adapters/linter-push-v2-adapter';
 import CommandExecutionAdapter from './adapters/command-execution-adapter';
+export { getExePath } from "./utils"
 
 export * from './auto-languageclient';
 export {

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -24,8 +24,10 @@ export interface LanguageServerProcess extends EventEmitter {
   pid: number;
 
   kill(signal?: NodeJS.Signals | number): void;
+  on(event: 'close', listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
+  on(event: 'disconnect', listener: () => void): this;
   on(event: 'error', listener: (err: Error) => void): this;
-  on(event: 'exit', listener: (code: number, signal: NodeJS.Signals | number) => void): this;
+  on(event: 'exit', listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
 }
 
 /** The necessary elements for a server that has started or is starting. */

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -1,8 +1,7 @@
 import Convert from './convert';
 import * as path from 'path';
-import * as stream from 'stream';
 import * as ls from './languageclient';
-import { EventEmitter } from 'events';
+import { ChildProcess } from 'child_process'
 import { Logger } from './logger';
 import {
   CompositeDisposable,
@@ -11,24 +10,16 @@ import {
 } from 'atom';
 import { ReportBusyWhile } from './utils';
 
-/**
- * Public: Defines the minimum surface area for an object that resembles a
- * ChildProcess.  This is used so that language packages with alternative
- * language server process hosting strategies can return something compatible
- * with AutoLanguageClient.startServerProcess.
- */
-export interface LanguageServerProcess extends EventEmitter {
-  stdin: stream.Writable;
-  stdout: stream.Readable;
-  stderr: stream.Readable;
-  pid: number;
 
-  kill(signal?: NodeJS.Signals | number): void;
-  on(event: 'close', listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
-  on(event: 'disconnect', listener: () => void): this;
-  on(event: 'error', listener: (err: Error) => void): this;
-  on(event: 'exit', listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
-}
+type MinimalLanguageServerProcess = Pick<ChildProcess, 'stdin' | 'stdout' | 'stderr' | 'pid' | 'kill' | 'on'>
+
+/**
+ * Public: Defines a language server process which is either a ChildProcess, or it is a minimal object that resembles a
+ * ChildProcess.
+ * `MinimalLanguageServerProcess` is used so that language packages with alternative language server process hosting strategies
+ * can return something compatible with `AutoLanguageClient.startServerProcess`.
+ */
+export type LanguageServerProcess = ChildProcess | MinimalLanguageServerProcess
 
 /** The necessary elements for a server that has started or is starting. */
 export interface ActiveServer {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -114,8 +114,8 @@ export function promiseWithTimeout<T>(ms: number, promise: Promise<T>): Promise<
 }
 
 
-/** Finds an exe file in the package assuming it is placed under `rootPath/platform/exe`
- * For example on Windows, if the `exeName` is `serve-d`, it returns the absolute path to `bin/win32/exeName.exe`
+/** Finds an exe file in the package assuming it is placed under `rootPath/platform-arch/exe`
+ * For example on Windows x64, if the `exeName` is `serve-d`, it returns the absolute path to `./bin/win32-x64/exeName.exe`
  * @param exeName name of the exe file
  * @param rootPath the path of the folder of the exe file. Defaults to 'bin'
  * @param exeExtention the extention of the exe file. Defaults to `process.platform === "win32" ? ".exe" : ""`
@@ -125,5 +125,5 @@ export function getExePath(
  rootPath = "bin",
  exeExtention = process.platform === "win32" ? ".exe" : ""
 ): string {
- return resolve(join(rootPath, process.platform, `${exeName}${exeExtention}`));
+ return resolve(join(rootPath, `${process.platform}-${process.arch}`, `${exeName}${exeExtention}`));
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -117,13 +117,13 @@ export function promiseWithTimeout<T>(ms: number, promise: Promise<T>): Promise<
 /** Finds an exe file in the package assuming it is placed under `rootPath/platform-arch/exe`
  * For example on Windows x64, if the `exeName` is `serve-d`, it returns the absolute path to `./bin/win32-x64/exeName.exe`
  * @param exeName name of the exe file
- * @param rootPath the path of the folder of the exe file. Defaults to 'bin'
+ * @param rootPath the path of the folder of the exe file. Defaults to 'join("bin", `${process.platform}-${process.arch}`)'
  * @param exeExtention the extention of the exe file. Defaults to `process.platform === "win32" ? ".exe" : ""`
  */
 export function getExePath(
  exeName: string,
- rootPath = "bin",
+ rootPath = join("bin", `${process.platform}-${process.arch}`),
  exeExtention = process.platform === "win32" ? ".exe" : ""
 ): string {
- return resolve(join(rootPath, `${process.platform}-${process.arch}`, `${exeName}${exeExtention}`));
+ return resolve(join(rootPath, `${exeName}${exeExtention}`));
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,3 +1,4 @@
+import { join, resolve } from 'path';
 import {
   Point,
   TextBuffer,
@@ -110,4 +111,19 @@ export function promiseWithTimeout<T>(ms: number, promise: Promise<T>): Promise<
       reject(err);
     });
   });
+}
+
+
+/** Finds an exe file in the package assuming it is placed under `rootPath/platform/exe`
+ * For example on Windows, if the `exeName` is `serve-d`, it returns the absolute path to `bin/win32/exeName.exe`
+ * @param exeName name of the exe file
+ * @param rootPath the path of the folder of the exe file. Defaults to 'bin'
+ * @param exeExtention the extention of the exe file. Defaults to `process.platform === "win32" ? ".exe" : ""`
+ */
+export function getExePath(
+ exeName: string,
+ rootPath = "bin",
+ exeExtention = process.platform === "win32" ? ".exe" : ""
+): string {
+ return resolve(join(rootPath, process.platform, `${exeName}${exeExtention}`));
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -115,6 +115,9 @@ export function promiseWithTimeout<T>(ms: number, promise: Promise<T>): Promise<
 }
 
 
+export const rootPathDefault = join("bin", `${process.platform}-${process.arch}`);
+export const exeExtentionDefault = process.platform === "win32" ? ".exe" : "";
+
 /** Finds an exe file in the package assuming it is placed under `rootPath/platform-arch/exe`. If the exe file did not exist,
  * the given name is returned.
  * For example on Windows x64, if the `exeName` is `serve-d`, it returns the absolute path to `./bin/win32-x64/exeName.exe`, and
@@ -123,11 +126,7 @@ export function promiseWithTimeout<T>(ms: number, promise: Promise<T>): Promise<
  * @param rootPath the path of the folder of the exe file. Defaults to 'join("bin", `${process.platform}-${process.arch}`)'
  * @param exeExtention the extention of the exe file. Defaults to `process.platform === "win32" ? ".exe" : ""`
  */
-export function getExePath(
- exeName: string,
- rootPath = join("bin", `${process.platform}-${process.arch}`),
- exeExtention = process.platform === "win32" ? ".exe" : ""
-): string {
+export function getExePath(exeName: string, rootPath = rootPathDefault, exeExtention = exeExtentionDefault): string {
  const exePath = resolve(join(rootPath, `${exeName}${exeExtention}`));
  if (existsSync(exePath)) {
    return exePath

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,5 @@
 import { join, resolve } from 'path';
+import  { existsSync } from 'fs';
 import {
   Point,
   TextBuffer,
@@ -114,8 +115,10 @@ export function promiseWithTimeout<T>(ms: number, promise: Promise<T>): Promise<
 }
 
 
-/** Finds an exe file in the package assuming it is placed under `rootPath/platform-arch/exe`
- * For example on Windows x64, if the `exeName` is `serve-d`, it returns the absolute path to `./bin/win32-x64/exeName.exe`
+/** Finds an exe file in the package assuming it is placed under `rootPath/platform-arch/exe`. If the exe file did not exist,
+ * the given name is returned.
+ * For example on Windows x64, if the `exeName` is `serve-d`, it returns the absolute path to `./bin/win32-x64/exeName.exe`, and
+ * if the file did not exist, `serve-d` is returned.
  * @param exeName name of the exe file
  * @param rootPath the path of the folder of the exe file. Defaults to 'join("bin", `${process.platform}-${process.arch}`)'
  * @param exeExtention the extention of the exe file. Defaults to `process.platform === "win32" ? ".exe" : ""`
@@ -125,5 +128,10 @@ export function getExePath(
  rootPath = join("bin", `${process.platform}-${process.arch}`),
  exeExtention = process.platform === "win32" ? ".exe" : ""
 ): string {
- return resolve(join(rootPath, `${exeName}${exeExtention}`));
+ const exePath = resolve(join(rootPath, `${exeName}${exeExtention}`));
+ if (existsSync(exePath)) {
+   return exePath
+ } else {
+   return exeName
+ }
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -42,8 +42,9 @@ describe('Utils', () => {
       expect(exePath).eq(expectedExe);
     })
     it('returns the exe path for the given root', () => {
-      const exePath = Utils.getExePath('serve-d', __dirname);
-      let expectedExe = join(__dirname, `${process.platform}-${process.arch}`, 'serve-d');
+      const rootPath = join(__dirname, `${process.platform}-${process.arch}`);
+      const exePath = Utils.getExePath('serve-d', rootPath);
+      let expectedExe = join(rootPath, 'serve-d');
       if (process.platform === 'win32') {
         expectedExe = expectedExe + '.exe';
       }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -2,7 +2,7 @@ import * as Utils from '../lib/utils';
 import { createFakeEditor } from './helpers';
 import { expect } from 'chai';
 import { Point } from 'atom';
-import { join, dirname } from 'path'
+import { join } from 'path'
 
 describe('Utils', () => {
   describe('getWordAtPosition', () => {
@@ -35,7 +35,7 @@ describe('Utils', () => {
   describe('getExePath', () => {
     it('returns the exe path under bin folder by default', () => {
       const exePath = Utils.getExePath('serve-d');
-      let expectedExe = join(dirname(dirname(__dirname)), 'bin', process.platform, 'serve-d');
+      let expectedExe = join(process.cwd(), 'bin', `${process.platform}-${process.arch}`, 'serve-d');
       if (process.platform === 'win32') {
         expectedExe = expectedExe + '.exe';
       }
@@ -43,7 +43,7 @@ describe('Utils', () => {
     })
     it('returns the exe path for the given root', () => {
       const exePath = Utils.getExePath('serve-d', __dirname);
-      let expectedExe = join(__dirname, process.platform, 'serve-d');
+      let expectedExe = join(__dirname, `${process.platform}-${process.arch}`, 'serve-d');
       if (process.platform === 'win32') {
         expectedExe = expectedExe + '.exe';
       }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -3,6 +3,8 @@ import { createFakeEditor } from './helpers';
 import { expect } from 'chai';
 import { Point } from 'atom';
 import { join } from 'path'
+import * as fs from 'fs'
+import * as sinon from 'sinon'
 
 describe('Utils', () => {
   describe('getWordAtPosition', () => {
@@ -34,21 +36,37 @@ describe('Utils', () => {
 
   describe('getExePath', () => {
     it('returns the exe path under bin folder by default', () => {
-      const exePath = Utils.getExePath('serve-d');
       let expectedExe = join(process.cwd(), 'bin', `${process.platform}-${process.arch}`, 'serve-d');
       if (process.platform === 'win32') {
         expectedExe = expectedExe + '.exe';
       }
+
+      const fsMock = sinon.mock(fs);
+      fsMock.expects('existsSync').withArgs(expectedExe).returns(true);
+
+      const exePath = Utils.getExePath('serve-d');
       expect(exePath).eq(expectedExe);
+
+      fsMock.restore();
     })
     it('returns the exe path for the given root', () => {
       const rootPath = join(__dirname, `${process.platform}-${process.arch}`);
-      const exePath = Utils.getExePath('serve-d', rootPath);
       let expectedExe = join(rootPath, 'serve-d');
       if (process.platform === 'win32') {
         expectedExe = expectedExe + '.exe';
       }
+
+      const fsMock = sinon.mock(fs);
+      fsMock.expects('existsSync').withArgs(expectedExe).returns(true);
+
+      const exePath = Utils.getExePath('serve-d', rootPath);
       expect(exePath).eq(expectedExe);
+
+      fsMock.restore();
+    })
+    it('returns the exe name if the file does not exist under rootPath', () => {
+      const exePath = Utils.getExePath('python');
+      expect(exePath).eq('python');
     })
   })
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -2,6 +2,7 @@ import * as Utils from '../lib/utils';
 import { createFakeEditor } from './helpers';
 import { expect } from 'chai';
 import { Point } from 'atom';
+import { join, dirname } from 'path'
 
 describe('Utils', () => {
   describe('getWordAtPosition', () => {
@@ -30,4 +31,23 @@ describe('Utils', () => {
       expect(range.serialize()).eql([[0, 4], [0, 4]]);
     });
   });
+
+  describe('getExePath', () => {
+    it('returns the exe path under bin folder by default', () => {
+      const exePath = Utils.getExePath('serve-d');
+      let expectedExe = join(dirname(dirname(__dirname)), 'bin', process.platform, 'serve-d');
+      if (process.platform === 'win32') {
+        expectedExe = expectedExe + '.exe';
+      }
+      expect(exePath).eq(expectedExe);
+    })
+    it('returns the exe path for the given root', () => {
+      const exePath = Utils.getExePath('serve-d', __dirname);
+      let expectedExe = join(__dirname, process.platform, 'serve-d');
+      if (process.platform === 'win32') {
+        expectedExe = expectedExe + '.exe';
+      }
+      expect(exePath).eq(expectedExe);
+    })
+  })
 });


### PR DESCRIPTION
This fills the gap for native language servers such as for D, Java, etc, or the executables that are not a JavaScript file such as for Python.

- feat: add functions for spawning a general executable: `AutolanguageClient.spawn`
- allow custom handlers for lsProcess `onSpawnClose`, `onSpawnExit`, `onSpawnError`, `onSpawnDisconnect`
- fix LanguageServerProcess type 