### PR TITLE
Feature: handling custom requests

### DIFF
--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -102,7 +102,9 @@ export class LanguageClientConnection extends EventEmitter {
     this._onNotification({ method }, callback)
   }
 
-  // @deprecated Use onCustomNotification method instead
+  /**
+   * @deprecated Use `onCustomNotification` method instead
+   */
   public onCustom(method: string, callback: (obj: object) => void): void {
     this.onCustomNotification(method, callback)
   }

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -17,6 +17,7 @@ export interface KnownNotifications {
 export interface KnownRequests {
   "window/showMessageRequest": [lsp.ShowMessageRequestParams, lsp.MessageActionItem | null]
   "workspace/applyEdit": [lsp.ApplyWorkspaceEditParams, lsp.ApplyWorkspaceEditResponse]
+  [custom: string]: [object, object | null]
 }
 
 export type RequestCallback<T extends keyof KnownRequests> = KnownRequests[T] extends [infer U, infer V]
@@ -91,14 +92,30 @@ export class LanguageClientConnection extends EventEmitter {
   }
 
   /**
-   * Public: Register a callback for a custom message.
+   * Public: Register a callback for a custom notification
    *
    * @param method A string containing the name of the message to listen for.
    * @param callback The function to be called when the message is received.
    *   The payload from the message is passed to the function.
    */
-  public onCustom(method: string, callback: (obj: object) => void): void {
+  public onCustomNotification(method: string, callback: (obj: object) => void): void {
     this._onNotification({ method }, callback)
+  }
+
+  // @deprecated Use onCustomNotification method instead
+  public onCustom(method: string, callback: (obj: object) => void): void {
+    this.onCustomNotification(method, callback)
+  }
+
+  /**
+   * Public: Register a callback for a custom request
+   *
+   * @param method A string containing the name of the message to listen for.
+   * @param callback The function to be called when the message is received.
+   *   The payload from the message is passed to the function.
+   */
+  public onCustomRequest(method: string, callback: (obj: object) => Promise<object>): void {
+    this._onRequest({ method }, callback)
   }
 
   /**

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -17,7 +17,7 @@ export interface KnownNotifications {
 export interface KnownRequests {
   "window/showMessageRequest": [lsp.ShowMessageRequestParams, lsp.MessageActionItem | null]
   "workspace/applyEdit": [lsp.ApplyWorkspaceEditParams, lsp.ApplyWorkspaceEditResponse]
-  [custom: string]: [object, object | null]
+  [custom: string]: [Record<string, any>, Record<string, any> | null]
 }
 
 export type RequestCallback<T extends keyof KnownRequests> = KnownRequests[T] extends [infer U, infer V]
@@ -116,7 +116,10 @@ export class LanguageClientConnection extends EventEmitter {
    * @param callback The function to be called when the message is received.
    *   The payload from the message is passed to the function.
    */
-  public onCustomRequest(method: string, callback: (obj: object) => Promise<object>): void {
+  public onCustomRequest(
+    method: string,
+    callback: (obj: Record<string, any>) => Promise<Record<string, any> | null>
+  ): void {
     this._onRequest({ method }, callback)
   }
 


### PR DESCRIPTION
Ported https://github.com/atom/atom-languageclient/pull/249 to the new repo.

- added missing `onCustomRequest` method
- renamed `onCustom` to `onCustomNotification`