### PR TITLE
refactor: clean-up module augments

### DIFF
--- a/lib/adapters/notifications-adapter.ts
+++ b/lib/adapters/notifications-adapter.ts
@@ -5,7 +5,7 @@ import {
   ShowMessageParams,
   ShowMessageRequestParams,
 } from "../languageclient"
-import { Notification, NotificationOptions, NotificationExt } from "atom"
+import { Notification, NotificationOptions } from "atom"
 
 export interface NotificationButton {
   text: string
@@ -109,7 +109,7 @@ function addNotificationForMessage(
   message: string,
   options: NotificationOptions
 ): Notification | null {
-  function isDuplicate(note: NotificationExt): boolean {
+  function isDuplicate(note: Notification): boolean {
     const noteDismissed = note.isDismissed && note.isDismissed()
     const noteOptions = (note.getOptions && note.getOptions()) || {}
     return (

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,6 @@
 import { join, resolve } from "path"
 import { existsSync } from "fs"
-import { Point, TextBuffer, TextEditor, TextEditorExt, Range, BufferScanResult } from "atom"
+import { Point, TextBuffer, TextEditor, Range, BufferScanResult } from "atom"
 import { CancellationToken, CancellationTokenSource } from "vscode-jsonrpc"
 
 export type ReportBusyWhile = <T>(title: string, f: () => Promise<T>) => Promise<T>
@@ -10,7 +10,7 @@ export type ReportBusyWhile = <T>(title: string, f: () => Promise<T>) => Promise
  * Uses the non-word characters from the position's grammar scope.
  */
 export function getWordAtPosition(editor: TextEditor, position: Point): Range {
-  const nonWordCharacters = escapeRegExp((editor as TextEditorExt).getNonWordCharacters(position))
+  const nonWordCharacters = escapeRegExp(editor.getNonWordCharacters(position))
   const range = _getRegexpRangeAtPosition(
     editor.getBuffer(),
     position,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@atom/mocha-test-runner": "^1.6.1",
-    "@types/atom": "^1.40.9",
+    "@types/atom": "^1.40.10",
     "@types/chai": "^4.2.14",
     "@types/mocha": "^8.2.0",
     "@types/node": "14.14.22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ dependencies:
   zadeh: 2.0.2
 devDependencies:
   '@atom/mocha-test-runner': 1.6.1
-  '@types/atom': 1.40.9
+  '@types/atom': 1.40.10
   '@types/chai': 4.2.15
   '@types/mocha': 8.2.1
   '@types/node': 14.14.22
@@ -301,12 +301,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
-  /@types/atom/1.40.9:
+  /@types/atom/1.40.10:
     dependencies:
       '@types/node': 14.14.22
     dev: true
     resolution:
-      integrity: sha512-ulAFivA0yzxbMrmjtT1edJ+VaOeUsaV9/ZG9429POm5BnhcgLkAsMpQnQCJeYiZ7ZEQCsQ9LMv1uf7PJj0QyOg==
+      integrity: sha512-aNFUhCuR6nmTTMoYKfWWMifZ3IcNETLWC75hCdg3i1/OvirfR/5qm1wfiISBb4s/TPM2YVEtxytCdWhKJuEhzw==
   /@types/chai/4.2.15:
     dev: true
     resolution:
@@ -3875,7 +3875,7 @@ packages:
       integrity: sha512-20vaD+PTkqYHuvKMDMfFSOYaw4QB6tLQQteHF2mjhnXfeyP0+sCEaord7mI5QdPwrOnR4TAMi9AS2zBL/HA0BQ==
 specifiers:
   '@atom/mocha-test-runner': ^1.6.1
-  '@types/atom': ^1.40.9
+  '@types/atom': ^1.40.10
   '@types/chai': ^4.2.14
   '@types/mocha': ^8.2.0
   '@types/node': 14.14.22

--- a/typings/atom/index.d.ts
+++ b/typings/atom/index.d.ts
@@ -1,12 +1,19 @@
 import { Point, Notification, NotificationOptions, TextEditor } from "atom"
 
-declare module "atom" {
-  interface TextEditorExt extends TextEditor {
+// NOTE: due to a bug in how TypeScript resolves ambient augments,
+// need to be more specific here for TextEditor to keep its "class"
+// status and not be demoted to "interface". Should revert this
+// once the issue is fixed.
+declare module "atom/src/text-editor" {
+  interface TextEditor {
     getNonWordCharacters(position: Point): string
   }
+}
 
+// NOTE: same here
+declare module "atom/src/notification" {
   /** Non-public Notification api */
-  interface NotificationExt extends Notification {
+  interface Notification {
     isDismissed?: () => boolean
     getOptions?: () => NotificationOptions | null
   }

--- a/typings/atom/index.d.ts
+++ b/typings/atom/index.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-shadow, @typescript-eslint/no-unused-vars */
 import { Point, Notification, NotificationOptions, TextEditor } from "atom"
 
 // NOTE: due to a bug in how TypeScript resolves ambient augments,


### PR DESCRIPTION
This is still not pretty, but arguably less painful than those `*Ext` declarations.

I can't spend much time now on searching through the TypeScript issue tracker and/or constructing a minimal testcase for the bugreport, but we should at least check if it's been already reported at some point.