### PR TITLE
feat: initial code actions backend for Linter service 

### DIFF
--- a/lib/adapters/code-action-adapter.ts
+++ b/lib/adapters/code-action-adapter.ts
@@ -103,7 +103,7 @@ function createCodeActionParams(
     diagnostics = []
   } else {
     // TODO compile time dispatch using function names
-    diagnostics = isLinterMessage(linterMessages)
+    diagnostics = areLinterMessages(linterMessages)
       ? linterAdapter.getLSDiagnosticsForMessages(linterMessages as linter.Message[])
       : (linterAdapter as IdeDiagnosticAdapter).getLSDiagnosticsForIdeDiagnostics(
           linterMessages as atomIde.Diagnostic[],
@@ -119,8 +119,8 @@ function createCodeActionParams(
   }
 }
 
-function isLinterMessage(linterMessage: linter.Message[] | atomIde.Diagnostic[]): boolean {
-  if (linterMessage.length > 0 && "excerpt" in linterMessage[0]) {
+function areLinterMessages(linterMessages: linter.Message[] | atomIde.Diagnostic[]): boolean {
+  if ("excerpt" in linterMessages[0]) {
     return true
   }
   return false

--- a/lib/adapters/code-action-adapter.ts
+++ b/lib/adapters/code-action-adapter.ts
@@ -31,8 +31,8 @@ export default class CodeActionAdapter {
    * @param serverCapabilities The {ServerCapabilities} of the language server that will be used.
    * @param editor The Atom {TextEditor} containing the diagnostics.
    * @param range The Atom {Range} to fetch code actions for.
-   * @param linterMessages An {Array<linter$Message>} to fetch code actions for.
-   *   This is typically a list of messages intersecting `range`.
+   * @param linterMessages An {Array<linter$Message>} to fetch code actions for. This is typically a list of messages
+   *   intersecting `range`.
    * @returns A {Promise} of an {Array} of {atomIde$CodeAction}s to display.
    */
   public static async getCodeActions(

--- a/lib/adapters/code-action-adapter.ts
+++ b/lib/adapters/code-action-adapter.ts
@@ -1,5 +1,8 @@
 import type * as atomIde from "atom-ide-base"
+import * as linter from "atom/linter"
 import LinterPushV2Adapter from "./linter-push-v2-adapter"
+/* eslint-disable import/no-deprecated */
+import IdeDiagnosticAdapter from "./diagnostic-adapter"
 import assert = require("assert")
 import Convert from "../convert"
 import ApplyEditAdapter from "./apply-edit-adapter"
@@ -7,6 +10,7 @@ import {
   CodeAction,
   CodeActionParams,
   Command,
+  Diagnostic,
   LanguageClientConnection,
   ServerCapabilities,
   WorkspaceEdit,
@@ -27,24 +31,24 @@ export default class CodeActionAdapter {
    * @param serverCapabilities The {ServerCapabilities} of the language server that will be used.
    * @param editor The Atom {TextEditor} containing the diagnostics.
    * @param range The Atom {Range} to fetch code actions for.
-   * @param diagnostics An {Array<atomIde$Diagnostic>} to fetch code actions for. This is typically a list of
-   *   diagnostics intersecting `range`.
+   * @param linterMessages An {Array<linter$Message>} to fetch code actions for.
+   *   This is typically a list of messages intersecting `range`.
    * @returns A {Promise} of an {Array} of {atomIde$CodeAction}s to display.
    */
   public static async getCodeActions(
     connection: LanguageClientConnection,
     serverCapabilities: ServerCapabilities,
-    linterAdapter: LinterPushV2Adapter | undefined,
+    linterAdapter: LinterPushV2Adapter | IdeDiagnosticAdapter | undefined,
     editor: TextEditor,
     range: Range,
-    diagnostics: atomIde.Diagnostic[]
+    linterMessages: linter.Message[] | atomIde.Diagnostic[]
   ): Promise<atomIde.CodeAction[]> {
     if (linterAdapter == null) {
       return []
     }
     assert(serverCapabilities.codeActionProvider, "Must have the textDocument/codeAction capability")
 
-    const params = CodeActionAdapter.createCodeActionParams(linterAdapter, editor, range, diagnostics)
+    const params = createCodeActionParams(linterAdapter, editor, range, linterMessages)
     const actions = await connection.codeAction(params)
     if (actions === null) {
       return []
@@ -86,31 +90,38 @@ export default class CodeActionAdapter {
       })
     }
   }
+}
 
-  private static createCodeActionParams(
-    linterAdapter: LinterPushV2Adapter,
-    editor: TextEditor,
-    range: Range,
-    diagnostics: atomIde.Diagnostic[]
-  ): CodeActionParams {
-    return {
-      textDocument: Convert.editorToTextDocumentIdentifier(editor),
-      range: Convert.atomRangeToLSRange(range),
-      context: {
-        diagnostics: diagnostics.map((diagnostic) => {
-          // Retrieve the stored diagnostic code if it exists.
-          // Until the Linter API provides a place to store the code,
-          // there's no real way for the code actions API to give it back to us.
-          const converted = Convert.atomIdeDiagnosticToLSDiagnostic(diagnostic)
-          if (diagnostic.range != null && diagnostic.text != null) {
-            const code = linterAdapter.getDiagnosticCode(editor, diagnostic.range, diagnostic.text)
-            if (code != null) {
-              converted.code = code
-            }
-          }
-          return converted
-        }),
-      },
-    }
+function createCodeActionParams(
+  linterAdapter: LinterPushV2Adapter | IdeDiagnosticAdapter,
+  editor: TextEditor,
+  range: Range,
+  linterMessages: linter.Message[] | atomIde.Diagnostic[]
+): CodeActionParams {
+  let diagnostics: Diagnostic[]
+  if (linterMessages.length === 0) {
+    diagnostics = []
+  } else {
+    // TODO compile time dispatch using function names
+    diagnostics = isLinterMessage(linterMessages)
+      ? linterAdapter.getLSDiagnosticsForMessages(linterMessages as linter.Message[])
+      : (linterAdapter as IdeDiagnosticAdapter).getLSDiagnosticsForIdeDiagnostics(
+          linterMessages as atomIde.Diagnostic[],
+          editor
+        )
   }
+  return {
+    textDocument: Convert.editorToTextDocumentIdentifier(editor),
+    range: Convert.atomRangeToLSRange(range),
+    context: {
+      diagnostics,
+    },
+  }
+}
+
+function isLinterMessage(linterMessage: linter.Message[] | atomIde.Diagnostic[]): boolean {
+  if (linterMessage.length > 0 && "excerpt" in linterMessage[0]) {
+    return true
+  }
+  return false
 }

--- a/lib/adapters/code-action-adapter.ts
+++ b/lib/adapters/code-action-adapter.ts
@@ -12,7 +12,6 @@ import {
   WorkspaceEdit,
 } from "../languageclient"
 import { Range, TextEditor } from "atom"
-import CommandExecutionAdapter from "./command-execution-adapter"
 
 export default class CodeActionAdapter {
   /** @returns A {Boolean} indicating this adapter can adapt the server based on the given serverCapabilities. */
@@ -81,7 +80,10 @@ export default class CodeActionAdapter {
 
   private static async executeCommand(command: any, connection: LanguageClientConnection): Promise<void> {
     if (Command.is(command)) {
-      await CommandExecutionAdapter.executeCommand(connection, command.command, command.arguments)
+      await connection.executeCommand({
+        command: command.command,
+        arguments: command.arguments,
+      })
     }
   }
 

--- a/lib/adapters/diagnostic-adapter.ts
+++ b/lib/adapters/diagnostic-adapter.ts
@@ -1,0 +1,31 @@
+/** @deprecated diagnostic adapter */
+
+import * as atomIde from "atom-ide-base"
+import * as ls from "../languageclient"
+import Convert from "../convert"
+
+/** @deprecated use Linter V2 service */
+export function atomIdeDiagnosticToLSDiagnostic(diagnostic: atomIde.Diagnostic): ls.Diagnostic {
+  // TODO: support diagnostic codes and codeDescriptions
+  // TODO!: support data
+  return {
+    range: Convert.atomRangeToLSRange(diagnostic.range),
+    severity: diagnosticTypeToLSSeverity(diagnostic.type),
+    source: diagnostic.providerName,
+    message: diagnostic.text || "",
+  }
+}
+
+/** @deprecated use Linter V2 service */
+export function diagnosticTypeToLSSeverity(type: atomIde.DiagnosticType): ls.DiagnosticSeverity {
+  switch (type) {
+    case "Error":
+      return ls.DiagnosticSeverity.Error
+    case "Warning":
+      return ls.DiagnosticSeverity.Warning
+    case "Info":
+      return ls.DiagnosticSeverity.Information
+    default:
+      throw Error(`Unexpected diagnostic type ${type}`)
+  }
+}

--- a/lib/adapters/diagnostic-adapter.ts
+++ b/lib/adapters/diagnostic-adapter.ts
@@ -1,8 +1,63 @@
-/** @deprecated diagnostic adapter */
-
 import * as atomIde from "atom-ide-base"
+import * as atom from "atom"
 import * as ls from "../languageclient"
 import Convert from "../convert"
+
+/** @deprecated use Linter V2 service */
+export type DiagnosticCode = number | string
+
+/** @deprecated use Linter V2 service */
+export default class IdeDiagnosticAdapter {
+  private _diagnosticCodes: Map<string, Map<string, DiagnosticCode | null>> = new Map()
+
+  /** Public: get diagnostics for the given linter messages
+   * @deprecated use Linter V2 service
+   * @param linterMessages an array of linter {V2Message}
+   * @param editor
+   * @returns an array of LS {Diagnostic[]}
+   */
+  public getLSDiagnostics(diagnostics: atomIde.Diagnostic[], editor: atom.TextEditor): ls.Diagnostic[] {
+    return diagnostics.map((diagnostic) => this.getLSDiagnostic(diagnostic, editor))
+  }
+
+  /**
+   * Public: Get the {Diagnostic} that is associated with the given {atomIde.Diagnostic}.
+   * @deprecated use Linter V2 service
+   * @param diagnostic The {atomIde.Diagnostic} object to fetch the {Diagnostic} for.
+   * @param editor
+   * @returns The associated {Diagnostic}.
+   */
+  public getLSDiagnostic(diagnostic: atomIde.Diagnostic, editor: atom.TextEditor): ls.Diagnostic {
+    // Retrieve the stored diagnostic code if it exists.
+    // Until the Linter API provides a place to store the code,
+    // there's no real way for the code actions API to give it back to us.
+    const converted = atomIdeDiagnosticToLSDiagnostic(diagnostic)
+    if (diagnostic.range != null && diagnostic.text != null) {
+      const code = this.getDiagnosticCode(editor, diagnostic.range, diagnostic.text)
+      if (code != null) {
+        converted.code = code
+      }
+    }
+    return converted
+  }
+
+  /**
+   * Private: Get the recorded diagnostic code for a range/message.
+   * Diagnostic codes are tricky because there's no suitable place in the Linter API for them.
+   * For now, we'll record the original code for each range/message combination and retrieve it
+   * when needed (e.g. for passing back into code actions)
+   */
+  private getDiagnosticCode(editor: atom.TextEditor, range: atom.Range, text: string): DiagnosticCode | null {
+    const path = editor.getPath()
+    if (path != null) {
+      const diagnosticCodes = this._diagnosticCodes.get(path)
+      if (diagnosticCodes != null) {
+        return diagnosticCodes.get(getCodeKey(range, text)) || null
+      }
+    }
+    return null
+  }
+}
 
 /** @deprecated use Linter V2 service */
 export function atomIdeDiagnosticToLSDiagnostic(diagnostic: atomIde.Diagnostic): ls.Diagnostic {
@@ -28,4 +83,8 @@ export function diagnosticTypeToLSSeverity(type: atomIde.DiagnosticType): ls.Dia
     default:
       throw Error(`Unexpected diagnostic type ${type}`)
   }
+}
+
+function getCodeKey(range: atom.Range, text: string): string {
+  return ([] as any[]).concat(...range.serialize(), text).join(",")
 }

--- a/lib/adapters/diagnostic-adapter.ts
+++ b/lib/adapters/diagnostic-adapter.ts
@@ -4,19 +4,20 @@ import * as ls from "../languageclient"
 import Convert from "../convert"
 import LinterPushV2Adapter from "./linter-push-v2-adapter"
 
-/** @deprecated use Linter V2 service */
+/** @deprecated Use Linter V2 service */
 export type DiagnosticCode = number | string
 
-/** @deprecated use Linter V2 service */
+/** @deprecated Use Linter V2 service */
 export default class IdeDiagnosticAdapter extends LinterPushV2Adapter {
   private _diagnosticCodes: Map<string, Map<string, DiagnosticCode | null>> = new Map()
 
   /**
-   * Public: Capture the diagnostics sent from a langguage server, convert them to the
-   * Linter V2 format and forward them on to any attached {V2IndieDelegate}s.
-   * @deprecated use Linter V2 service
-   * @param params The {PublishDiagnosticsParams} received from the language server that should
-   *   be captured and forwarded on to any attached {V2IndieDelegate}s.
+   * Public: Capture the diagnostics sent from a langguage server, convert them to the Linter V2 format and forward them
+   * on to any attached {V2IndieDelegate}s.
+   *
+   * @deprecated Use Linter V2 service
+   * @param params The {PublishDiagnosticsParams} received from the language server that should be captured and
+   *   forwarded on to any attached {V2IndieDelegate}s.
    */
   public captureDiagnostics(params: ls.PublishDiagnosticsParams): void {
     const path = Convert.uriToPath(params.uri)
@@ -31,11 +32,13 @@ export default class IdeDiagnosticAdapter extends LinterPushV2Adapter {
     this._indies.forEach((i) => i.setMessages(path, messages))
   }
 
-  /** Public: get diagnostics for the given linter messages
-   * @deprecated use Linter V2 service
-   * @param linterMessages an array of linter {V2Message}
+  /**
+   * Public: get diagnostics for the given linter messages
+   *
+   * @deprecated Use Linter V2 service
+   * @param linterMessages An array of linter {V2Message}
    * @param editor
-   * @returns an array of LS {Diagnostic[]}
+   * @returns An array of LS {Diagnostic[]}
    */
   public getLSDiagnosticsForIdeDiagnostics(
     diagnostics: atomIde.Diagnostic[],
@@ -46,7 +49,8 @@ export default class IdeDiagnosticAdapter extends LinterPushV2Adapter {
 
   /**
    * Public: Get the {Diagnostic} that is associated with the given {atomIde.Diagnostic}.
-   * @deprecated use Linter V2 service
+   *
+   * @deprecated Use Linter V2 service
    * @param diagnostic The {atomIde.Diagnostic} object to fetch the {Diagnostic} for.
    * @param editor
    * @returns The associated {Diagnostic}.
@@ -66,10 +70,9 @@ export default class IdeDiagnosticAdapter extends LinterPushV2Adapter {
   }
 
   /**
-   * Private: Get the recorded diagnostic code for a range/message.
-   * Diagnostic codes are tricky because there's no suitable place in the Linter API for them.
-   * For now, we'll record the original code for each range/message combination and retrieve it
-   * when needed (e.g. for passing back into code actions)
+   * Private: Get the recorded diagnostic code for a range/message. Diagnostic codes are tricky because there's no
+   * suitable place in the Linter API for them. For now, we'll record the original code for each range/message
+   * combination and retrieve it when needed (e.g. for passing back into code actions)
    */
   private getDiagnosticCode(editor: atom.TextEditor, range: atom.Range, text: string): DiagnosticCode | null {
     const path = editor.getPath()
@@ -83,7 +86,7 @@ export default class IdeDiagnosticAdapter extends LinterPushV2Adapter {
   }
 }
 
-/** @deprecated use Linter V2 service */
+/** @deprecated Use Linter V2 service */
 export function atomIdeDiagnosticToLSDiagnostic(diagnostic: atomIde.Diagnostic): ls.Diagnostic {
   // TODO: support diagnostic codes and codeDescriptions
   // TODO!: support data
@@ -95,7 +98,7 @@ export function atomIdeDiagnosticToLSDiagnostic(diagnostic: atomIde.Diagnostic):
   }
 }
 
-/** @deprecated use Linter V2 service */
+/** @deprecated Use Linter V2 service */
 export function diagnosticTypeToLSSeverity(type: atomIde.DiagnosticType): ls.DiagnosticSeverity {
   switch (type) {
     case "Error":

--- a/lib/adapters/linter-push-v2-adapter.ts
+++ b/lib/adapters/linter-push-v2-adapter.ts
@@ -127,6 +127,31 @@ export default class LinterPushV2Adapter {
     return null
 
 /**
+ * Public: Convert a single {Diagnostic} received from a language server into a single
+ * {Message} expected by the Linter V2 API.
+ *
+ * @param path A string representing the path of the file the diagnostic belongs to.
+ * @param diagnostics A {Diagnostic} object received from the language server.
+ * @returns A {Message} equivalent to the {Diagnostic} object supplied by the language server.
+ */
+function lsDiagnosticToV2Message(path: string, diagnostic: Diagnostic): linter.Message {
+  return {
+    location: {
+      file: path,
+      position: Convert.lsRangeToAtomRange(diagnostic.range),
+    },
+    reference: relatedInformationToReference(diagnostic.relatedInformation),
+    url: diagnostic.codeDescription?.href,
+    icon: iconForLSSeverity(diagnostic.severity ?? DiagnosticSeverity.Error),
+    excerpt: diagnostic.message,
+    linterName: diagnostic.source,
+    severity: lsSeverityToV2MessageSeverity(diagnostic.severity ?? DiagnosticSeverity.Error),
+    // BLOCKED: on steelbrain/linter#1722
+    solutions: undefined,
+  }
+}
+
+/**
  * Convert a severity level of an LSP {Diagnostic} to that of a Base Linter v2 {Message}.
  * Note: this conversion is lossy due to the v2 Message not being able to represent hints.
  *

--- a/lib/adapters/linter-push-v2-adapter.ts
+++ b/lib/adapters/linter-push-v2-adapter.ts
@@ -128,6 +128,17 @@ export default class LinterPushV2Adapter {
   }
 }
 
+/**
+ * Get a unique key for a Linter v2 Message
+ * @param message A {Message} object
+ * @returns ${string} a unique key
+ */
+function getMessageKey(message: linter.Message): string {
+  if (typeof message.key !== "string") {
+    updateMessageKey(message)
+  }
+  return message.key as string // updateMessageKey adds message.key string
+}
 
 /**
  * Construct an unique key for a Linter v2 Message and store it in `Message.key`

--- a/lib/adapters/linter-push-v2-adapter.ts
+++ b/lib/adapters/linter-push-v2-adapter.ts
@@ -98,6 +98,19 @@ export default class LinterPushV2Adapter {
     }
   }
 
+  /** Public: get diagnostics for the given linter messages
+   * @param linterMessages an array of linter {V2Message}
+   * @returns an array of LS {Diagnostic[]}
+   */
+  public getLSDiagnostics(linterMessages: linter.Message[]): Diagnostic[] {
+    return (
+      linterMessages
+        .map(this.getLSDiagnostic)
+        // filter out undefined
+        .filter((diagnostic) => diagnostic !== undefined) as Diagnostic[]
+    )
+  }
+
   /**
    * Public: Get the {Diagnostic} that is associated with the given Base Linter v2 {Message}.
    *

--- a/lib/adapters/linter-push-v2-adapter.ts
+++ b/lib/adapters/linter-push-v2-adapter.ts
@@ -127,6 +127,27 @@ export default class LinterPushV2Adapter {
     return null
 
 /**
+ * Convert a diagnostic severity number obtained from the language server into an Octicon icon.
+ *
+ * @param severity A number representing the severity of the diagnostic.
+ * @returns An Octicon name.
+ */
+function iconForLSSeverity(severity: DiagnosticSeverity): string | undefined {
+  switch (severity) {
+    case DiagnosticSeverity.Error:
+      return "stop"
+    case DiagnosticSeverity.Warning:
+      return "warning"
+    case DiagnosticSeverity.Information:
+      return "info"
+    case DiagnosticSeverity.Hint:
+      return "light-bulb"
+    default:
+      return undefined
+  }
+}
+
+/**
  * Convert the related information from a diagnostic into
  * a reference point for a Linter {V2Message}.
  *

--- a/lib/adapters/linter-push-v2-adapter.ts
+++ b/lib/adapters/linter-push-v2-adapter.ts
@@ -16,14 +16,17 @@ export default class LinterPushV2Adapter {
   /*
    * A map from file path calculated using the LS diagnostic uri to an array of linter messages {linter.Message[]}
    */
-  private _diagnosticMap: Map<string, linter.Message[]> = new Map()
+  protected _diagnosticMap: Map<string, linter.Message[]> = new Map()
   /**
    * A map from file path {linter.Message["location"]["file"]} to a Map of all Message keys to Diagnostics ${Map<linter.Message["key"], Diagnostic>}
    * It has to be stored separately because a {Message} object cannot hold all of the information
    * that a {Diagnostic} provides, thus we store the original {Diagnostic} object.
    */
-  private _lsDiagnosticMap: Map<linter.Message["location"]["file"], Map<linter.Message["key"], Diagnostic>> = new Map()
-  private _indies: Set<linter.IndieDelegate> = new Set()
+  protected _lsDiagnosticMap: Map<
+    linter.Message["location"]["file"],
+    Map<linter.Message["key"], Diagnostic>
+  > = new Map()
+  protected _indies: Set<linter.IndieDelegate> = new Set()
 
   /**
    * Public: Create a new {LinterPushV2Adapter} that will listen for diagnostics via the supplied {LanguageClientConnection}.
@@ -102,10 +105,10 @@ export default class LinterPushV2Adapter {
    * @param linterMessages an array of linter {V2Message}
    * @returns an array of LS {Diagnostic[]}
    */
-  public getLSDiagnostics(linterMessages: linter.Message[]): Diagnostic[] {
+  public getLSDiagnosticsForMessages(linterMessages: linter.Message[]): Diagnostic[] {
     return (
       linterMessages
-        .map(this.getLSDiagnostic)
+        .map(this.getLSDiagnosticForMessage)
         // filter out undefined
         .filter((diagnostic) => diagnostic !== undefined) as Diagnostic[]
     )
@@ -117,7 +120,7 @@ export default class LinterPushV2Adapter {
    * @param message The {Message} object to fetch the {Diagnostic} for.
    * @returns The associated {Diagnostic}.
    */
-  public getLSDiagnostic(message: linter.Message): Diagnostic | undefined {
+  public getLSDiagnosticForMessage(message: linter.Message): Diagnostic | undefined {
     return this._lsDiagnosticMap.get(message.location.file)?.get(getMessageKey(message))
   }
 

--- a/lib/adapters/linter-push-v2-adapter.ts
+++ b/lib/adapters/linter-push-v2-adapter.ts
@@ -9,8 +9,8 @@ import {
 } from "../languageclient"
 
 /**
- * Public: Listen to diagnostics messages from the language server and publish them
- * to the user by way of the Linter Push (Indie) v2 API provided by the Base Linter package.
+ * Public: Listen to diagnostics messages from the language server and publish them to the user by way of the Linter
+ * Push (Indie) v2 API provided by the Base Linter package.
  */
 export default class LinterPushV2Adapter {
   /*
@@ -18,14 +18,12 @@ export default class LinterPushV2Adapter {
    */
   protected _diagnosticMap: Map<string, linter.Message[]> = new Map()
   /**
-   * A map from file path {linter.Message["location"]["file"]} to a Map of all Message keys to Diagnostics ${Map<linter.Message["key"], Diagnostic>}
-   * It has to be stored separately because a {Message} object cannot hold all of the information
-   * that a {Diagnostic} provides, thus we store the original {Diagnostic} object.
+   * A map from file path {linter.Message["location"]["file"]} to a Map of all Message keys to Diagnostics
+   * ${Map<linter.Message["key"], Diagnostic>} It has to be stored separately because a {Message} object cannot hold all
+   * of the information that a {Diagnostic} provides, thus we store the original {Diagnostic} object.
    */
-  protected _lsDiagnosticMap: Map<
-    linter.Message["location"]["file"],
-    Map<linter.Message["key"], Diagnostic>
-  > = new Map()
+  protected _lsDiagnosticMap: Map<linter.Message["location"]["file"], Map<linter.Message["key"], Diagnostic>> =
+    new Map()
   protected _indies: Set<linter.IndieDelegate> = new Set()
 
   /**
@@ -101,9 +99,11 @@ export default class LinterPushV2Adapter {
     }
   }
 
-  /** Public: get diagnostics for the given linter messages
-   * @param linterMessages an array of linter {V2Message}
-   * @returns an array of LS {Diagnostic[]}
+  /**
+   * Public: get diagnostics for the given linter messages
+   *
+   * @param linterMessages An array of linter {V2Message}
+   * @returns An array of LS {Diagnostic[]}
    */
   public getLSDiagnosticsForMessages(linterMessages: linter.Message[]): Diagnostic[] {
     return (
@@ -125,8 +125,8 @@ export default class LinterPushV2Adapter {
   }
 
   /**
-   * Public: Convert a diagnostic severity number obtained from the language server into
-   * the textual equivalent for a Linter {V2Message}.
+   * Public: Convert a diagnostic severity number obtained from the language server into the textual equivalent for a
+   * Linter {V2Message}.
    *
    * @param severity A number representing the severity of the diagnostic.
    * @returns A string of 'error', 'warning' or 'info' depending on the severity.
@@ -146,8 +146,7 @@ export default class LinterPushV2Adapter {
 }
 
 /**
- * Public: Convert a single {Diagnostic} received from a language server into a single
- * {Message} expected by the Linter V2 API.
+ * Public: Convert a single {Diagnostic} received from a language server into a single {Message} expected by the Linter V2 API.
  *
  * @param path A string representing the path of the file the diagnostic belongs to.
  * @param diagnostics A {Diagnostic} object received from the language server.
@@ -171,8 +170,8 @@ function lsDiagnosticToV2Message(path: string, diagnostic: Diagnostic): linter.M
 }
 
 /**
- * Convert a severity level of an LSP {Diagnostic} to that of a Base Linter v2 {Message}.
- * Note: this conversion is lossy due to the v2 Message not being able to represent hints.
+ * Convert a severity level of an LSP {Diagnostic} to that of a Base Linter v2 {Message}. Note: this conversion is lossy
+ * due to the v2 Message not being able to represent hints.
  *
  * @param severity A severity level of of an LSP {Diagnostic} to be converted.
  * @returns A severity level a Base Linter v2 {Message}.
@@ -213,8 +212,7 @@ function iconForLSSeverity(severity: DiagnosticSeverity): string | undefined {
 }
 
 /**
- * Convert the related information from a diagnostic into
- * a reference point for a Linter {V2Message}.
+ * Convert the related information from a diagnostic into a reference point for a Linter {V2Message}.
  *
  * @param relatedInfo Several related information objects (only the first is used).
  * @returns A value that is suitable for using as {V2Message}.reference.
@@ -235,6 +233,7 @@ function relatedInformationToReference(
 
 /**
  * Get a unique key for a Linter v2 Message
+ *
  * @param message A {Message} object
  * @returns ${string} a unique key
  */
@@ -247,6 +246,7 @@ function getMessageKey(message: linter.Message): string {
 
 /**
  * Construct an unique key for a Linter v2 Message and store it in `Message.key`
+ *
  * @param message A {Message} object to serialize.
  * @returns ${string} a unique key
  */

--- a/lib/adapters/linter-push-v2-adapter.ts
+++ b/lib/adapters/linter-push-v2-adapter.ts
@@ -127,6 +127,27 @@ export default class LinterPushV2Adapter {
     return null
 
 /**
+ * Convert a severity level of an LSP {Diagnostic} to that of a Base Linter v2 {Message}.
+ * Note: this conversion is lossy due to the v2 Message not being able to represent hints.
+ *
+ * @param severity A severity level of of an LSP {Diagnostic} to be converted.
+ * @returns A severity level a Base Linter v2 {Message}.
+ */
+function lsSeverityToV2MessageSeverity(severity: DiagnosticSeverity): linter.Message["severity"] {
+  switch (severity) {
+    case DiagnosticSeverity.Error:
+      return "error"
+    case DiagnosticSeverity.Warning:
+      return "warning"
+    case DiagnosticSeverity.Information:
+    case DiagnosticSeverity.Hint:
+      return "info"
+    default:
+      throw Error(`Unexpected diagnostic severity '${severity}'`)
+  }
+}
+
+/**
  * Convert a diagnostic severity number obtained from the language server into an Octicon icon.
  *
  * @param severity A number representing the severity of the diagnostic.

--- a/lib/adapters/linter-push-v2-adapter.ts
+++ b/lib/adapters/linter-push-v2-adapter.ts
@@ -128,6 +128,27 @@ export default class LinterPushV2Adapter {
   }
 }
 
-function getCodeKey(range: atom.Range, text: string): string {
-  return ([] as any[]).concat(...range.serialize(), text).join(",")
+
+/**
+ * Construct an unique key for a Linter v2 Message and store it in `Message.key`
+ * @param message A {Message} object to serialize.
+ * @returns ${string} a unique key
+ */
+function updateMessageKey(message: linter.Message): void {
+  // From https://github.com/steelbrain/linter/blob/fadd462914ef0a8ed5b73a489f662a9393bdbe9f/lib/helpers.ts#L50-L64
+  const { reference, location } = message
+  const nameStr = `$LINTER:${message.linterName}`
+  const locationStr = `$LOCATION:${location.file}$${location.position.start.row}$${location.position.start.column}$${location.position.end.row}$${location.position.end.column}`
+  const referenceStr = reference
+    ? `$REFERENCE:${reference.file}$${
+        reference.position ? `${reference.position.row}$${reference.position.column}` : ""
+      }`
+    : "$REFERENCE:null"
+  const excerptStr = `$EXCERPT:${message.excerpt}`
+  const severityStr = `$SEVERITY:${message.severity}`
+  const iconStr = message.icon ? `$ICON:${message.icon}` : "$ICON:null"
+  const urlStr = message.url ? `$URL:${message.url}` : "$URL:null"
+  const descriptionStr =
+    typeof message.description === "string" ? `$DESCRIPTION:${message.description}` : "$DESCRIPTION:null"
+  message.key = `${nameStr}${locationStr}${referenceStr}${excerptStr}${severityStr}${iconStr}${urlStr}${descriptionStr}`
 }

--- a/lib/adapters/linter-push-v2-adapter.ts
+++ b/lib/adapters/linter-push-v2-adapter.ts
@@ -125,6 +125,25 @@ export default class LinterPushV2Adapter {
       }
     }
     return null
+
+/**
+ * Convert the related information from a diagnostic into
+ * a reference point for a Linter {V2Message}.
+ *
+ * @param relatedInfo Several related information objects (only the first is used).
+ * @returns A value that is suitable for using as {V2Message}.reference.
+ */
+function relatedInformationToReference(
+  relatedInfo: DiagnosticRelatedInformation[] | undefined
+): linter.Message["reference"] {
+  if (relatedInfo === undefined || relatedInfo.length === 0) {
+    return undefined
+  }
+
+  const location = relatedInfo[0].location
+  return {
+    file: Convert.uriToPath(location.uri),
+    position: Convert.lsRangeToAtomRange(location.range).start,
   }
 }
 

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -2,6 +2,9 @@ import type * as atomIde from "atom-ide-base"
 import * as ls from "./languageclient"
 import { Point, FilesystemChange, Range, TextEditor } from "atom"
 
+// eslint-disable-next-line import/no-deprecated
+import { diagnosticTypeToLSSeverity, atomIdeDiagnosticToLSDiagnostic } from "./adapters/diagnostic-adapter"
+
 /**
  * Public: Class that contains a number of helper methods for general conversions between the language server protocol
  * and Atom/Atom packages.
@@ -177,28 +180,16 @@ export default class Convert {
     }
   }
 
+  /** @deprecated use Linter V2 service */
   public static atomIdeDiagnosticToLSDiagnostic(diagnostic: atomIde.Diagnostic): ls.Diagnostic {
-    // TODO: support diagnostic codes and codeDescriptions
-    // TODO!: support data
-    return {
-      range: Convert.atomRangeToLSRange(diagnostic.range),
-      severity: Convert.diagnosticTypeToLSSeverity(diagnostic.type),
-      source: diagnostic.providerName,
-      message: diagnostic.text || "",
-    }
+    // eslint-disable-next-line import/no-deprecated
+    return atomIdeDiagnosticToLSDiagnostic(diagnostic)
   }
 
+  /** @deprecated use Linter V2 service */
   public static diagnosticTypeToLSSeverity(type: atomIde.DiagnosticType): ls.DiagnosticSeverity {
-    switch (type) {
-      case "Error":
-        return ls.DiagnosticSeverity.Error
-      case "Warning":
-        return ls.DiagnosticSeverity.Warning
-      case "Info":
-        return ls.DiagnosticSeverity.Information
-      default:
-        throw Error(`Unexpected diagnostic type ${type}`)
-    }
+    // eslint-disable-next-line import/no-deprecated
+    return diagnosticTypeToLSSeverity(type)
   }
 
   /**

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -180,13 +180,13 @@ export default class Convert {
     }
   }
 
-  /** @deprecated use Linter V2 service */
+  /** @deprecated Use Linter V2 service */
   public static atomIdeDiagnosticToLSDiagnostic(diagnostic: atomIde.Diagnostic): ls.Diagnostic {
     // eslint-disable-next-line import/no-deprecated
     return atomIdeDiagnosticToLSDiagnostic(diagnostic)
   }
 
-  /** @deprecated use Linter V2 service */
+  /** @deprecated Use Linter V2 service */
   public static diagnosticTypeToLSSeverity(type: atomIde.DiagnosticType): ls.DiagnosticSeverity {
     // eslint-disable-next-line import/no-deprecated
     return diagnosticTypeToLSSeverity(type)

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -433,7 +433,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @returns A resolved {CodeAction} that can be applied immediately.
    */
   public codeActionResolve(params: lsp.CodeAction): Promise<lsp.CodeAction> {
-    return this._sendRequest("codeAction/resolve", params)
+    return this._sendRequest(lsp.CodeActionResolveRequest.type, params)
   }
 
   /**

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -419,10 +419,21 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Send a `textDocument/codeAction` request.
    *
    * @param params The {CodeActionParams} identifying the document, range and context for the code action.
-   * @returns A {Promise} containing an {Array} of {Commands}s that can be performed against the given documents range.
+   * @returns A {Promise} containing an {Array} of {Command}s or {CodeAction}s that can be performed
+   *   against the given documents range.
    */
   public codeAction(params: lsp.CodeActionParams): Promise<Array<lsp.Command | lsp.CodeAction> | null> {
     return this._sendRequest(lsp.CodeActionRequest.type, params)
+  }
+
+  /**
+   * Public: Send a `codeAction/resolve` request.
+   *
+   * @param params The {CodeAction} whose properties (e.g. `edit`) are to be resolved.
+   * @returns A resolved {CodeAction} that can be applied immediately.
+   */
+  public codeActionResolve(params: lsp.CodeAction): Promise<lsp.CodeAction> {
+    return this._sendRequest("codeAction/resolve", params)
   }
 
   /**

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -419,8 +419,8 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Send a `textDocument/codeAction` request.
    *
    * @param params The {CodeActionParams} identifying the document, range and context for the code action.
-   * @returns A {Promise} containing an {Array} of {Command}s or {CodeAction}s that can be performed
-   *   against the given documents range.
+   * @returns A {Promise} containing an {Array} of {Command}s or {CodeAction}s that can be performed against the given
+   *   documents range.
    */
   public codeAction(params: lsp.CodeActionParams): Promise<Array<lsp.Command | lsp.CodeAction> | null> {
     return this._sendRequest(lsp.CodeActionRequest.type, params)
@@ -597,9 +597,7 @@ export class LanguageClientConnection extends EventEmitter {
   }
 }
 
-/**
- * Contains additional information about the context in which a completion request is triggered.
- */
+/** Contains additional information about the context in which a completion request is triggered. */
 export interface CompletionContext {
   /** How the completion was triggered. */
   triggerKind: lsp.CompletionTriggerKind

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -586,9 +586,9 @@ export class LanguageClientConnection extends EventEmitter {
   }
 }
 
-export type DiagnosticCode = number | string
-
-/** Contains additional information about the context in which a completion request is triggered. */
+/**
+ * Contains additional information about the context in which a completion request is triggered.
+ */
 export interface CompletionContext {
   /** How the completion was triggered. */
   triggerKind: lsp.CompletionTriggerKind

--- a/test/adapters/code-action-adapter.test.ts
+++ b/test/adapters/code-action-adapter.test.ts
@@ -1,7 +1,8 @@
 import { Range } from "atom"
 import * as ls from "../../lib/languageclient"
 import CodeActionAdapter from "../../lib/adapters/code-action-adapter"
-import LinterPushV2Adapter from "../../lib/adapters/linter-push-v2-adapter"
+/* eslint-disable import/no-deprecated */
+import IdeDiagnosticAdapter from "../../lib/adapters/diagnostic-adapter"
 import { createSpyConnection, createFakeEditor } from "../helpers.js"
 
 describe("CodeActionAdapter", () => {
@@ -20,7 +21,7 @@ describe("CodeActionAdapter", () => {
   })
 
   describe("getCodeActions", () => {
-    it("fetches code actions from the connection", async () => {
+    it("fetches code actions from the connection when IdeDiagnosticAdapter is used", async () => {
       const connection = createSpyConnection()
       const languageClient = new ls.LanguageClientConnection(connection)
       const testCommand: ls.Command = {
@@ -31,7 +32,9 @@ describe("CodeActionAdapter", () => {
       spyOn(languageClient, "codeAction").and.returnValue(Promise.resolve([testCommand]))
       spyOn(languageClient, "executeCommand").and.callThrough()
 
-      const linterAdapter = new LinterPushV2Adapter(languageClient)
+      const linterAdapter = new IdeDiagnosticAdapter(languageClient)
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore private method
       spyOn(linterAdapter, "getDiagnosticCode").and.returnValue("test code")
 
       const testPath = "/test.txt"

--- a/test/adapters/diagnostics-adapter-test.ts
+++ b/test/adapters/diagnostics-adapter-test.ts
@@ -1,0 +1,38 @@
+/* eslint-disable import/no-deprecated */
+import { Range } from "atom"
+import { expect } from "chai"
+import * as path from "path"
+import IdeDiagnosticAdapter from "../../lib/adapters/diagnostic-adapter"
+import Convert from "../../lib/convert"
+import * as ls from "../../lib/languageclient"
+import { createFakeEditor, createSpyConnection } from "../helpers.js"
+
+describe("IdeDiagnosticAdapter", () => {
+  describe("captureDiagnostics", () => {
+    it("stores diagnostic codes and allows their retrival", () => {
+      const languageClient = new ls.LanguageClientConnection(createSpyConnection())
+      const adapter = new IdeDiagnosticAdapter(languageClient)
+      const testPath = path.join(__dirname, "test.txt")
+      adapter.captureDiagnostics({
+        uri: Convert.pathToUri(testPath),
+        diagnostics: [
+          {
+            message: "Test message",
+            range: {
+              start: { line: 1, character: 2 },
+              end: { line: 3, character: 4 },
+            },
+            source: "source",
+            code: "test code",
+            severity: ls.DiagnosticSeverity.Information,
+          },
+        ],
+      })
+
+      const mockEditor = createFakeEditor(testPath)
+      expect(adapter["getDiagnosticCode"](mockEditor, new Range([1, 2], [3, 4]), "Test message")).to.equal("test code")
+      expect(adapter["getDiagnosticCode"](mockEditor, new Range([1, 2], [3, 4]), "Test message2")).to.not.exist
+      expect(adapter["getDiagnosticCode"](mockEditor, new Range([1, 2], [3, 5]), "Test message")).to.not.exist
+    })
+  })
+})

--- a/test/adapters/diagnostics-adapter-test.ts
+++ b/test/adapters/diagnostics-adapter-test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-deprecated */
 import { Range } from "atom"
-import { expect } from "chai"
 import * as path from "path"
 import IdeDiagnosticAdapter from "../../lib/adapters/diagnostic-adapter"
 import Convert from "../../lib/convert"
@@ -34,9 +33,9 @@ describe("IdeDiagnosticAdapter", () => {
       // using private method
       // eslint-disable-next-line dot-notation
       const getDiagnosticCode = adapter["getDiagnosticCode"]
-      expect(getDiagnosticCode(mockEditor, new Range([1, 2], [3, 4]), "Test message")).to.equal("test code")
-      expect(getDiagnosticCode(mockEditor, new Range([1, 2], [3, 4]), "Test message2")).to.not.exist
-      expect(getDiagnosticCode(mockEditor, new Range([1, 2], [3, 5]), "Test message")).to.not.exist
+      expect(getDiagnosticCode(mockEditor, new Range([1, 2], [3, 4]), "Test message")).toEqual("test code")
+      expect(getDiagnosticCode(mockEditor, new Range([1, 2], [3, 4]), "Test message2")).toBeUndefined()
+      expect(getDiagnosticCode(mockEditor, new Range([1, 2], [3, 5]), "Test message")).toBeUndefined()
     })
   })
 })

--- a/test/adapters/diagnostics-adapter-test.ts
+++ b/test/adapters/diagnostics-adapter-test.ts
@@ -30,9 +30,13 @@ describe("IdeDiagnosticAdapter", () => {
       })
 
       const mockEditor = createFakeEditor(testPath)
-      expect(adapter["getDiagnosticCode"](mockEditor, new Range([1, 2], [3, 4]), "Test message")).to.equal("test code")
-      expect(adapter["getDiagnosticCode"](mockEditor, new Range([1, 2], [3, 4]), "Test message2")).to.not.exist
-      expect(adapter["getDiagnosticCode"](mockEditor, new Range([1, 2], [3, 5]), "Test message")).to.not.exist
+
+      // using private method
+      // eslint-disable-next-line dot-notation
+      const getDiagnosticCode = adapter["getDiagnosticCode"]
+      expect(getDiagnosticCode(mockEditor, new Range([1, 2], [3, 4]), "Test message")).to.equal("test code")
+      expect(getDiagnosticCode(mockEditor, new Range([1, 2], [3, 4]), "Test message2")).to.not.exist
+      expect(getDiagnosticCode(mockEditor, new Range([1, 2], [3, 5]), "Test message")).to.not.exist
     })
   })
 })

--- a/test/adapters/linter-push-v2-adapter.test.ts
+++ b/test/adapters/linter-push-v2-adapter.test.ts
@@ -1,9 +1,7 @@
 import LinterPushV2Adapter from "../../lib/adapters/linter-push-v2-adapter"
-import Convert from "../../lib/convert"
 import * as ls from "../../lib/languageclient"
-import * as path from "path"
 import { Point, Range } from "atom"
-import { createSpyConnection, createFakeEditor } from "../helpers.js"
+import { createSpyConnection } from "../helpers.js"
 
 describe("LinterPushV2Adapter", () => {
   describe("constructor", () => {
@@ -60,34 +58,6 @@ describe("LinterPushV2Adapter", () => {
     it('converts DiagnosticSeverity.Hint to "info"', () => {
       const severity = LinterPushV2Adapter.diagnosticSeverityToSeverity(ls.DiagnosticSeverity.Hint)
       expect(severity).toBe("info")
-    })
-  })
-
-  describe("captureDiagnostics", () => {
-    it("stores diagnostic codes and allows their retrival", () => {
-      const languageClient = new ls.LanguageClientConnection(createSpyConnection())
-      const adapter = new LinterPushV2Adapter(languageClient)
-      const testPath = path.join(__dirname, "test.txt")
-      adapter.captureDiagnostics({
-        uri: Convert.pathToUri(testPath),
-        diagnostics: [
-          {
-            message: "Test message",
-            range: {
-              start: { line: 1, character: 2 },
-              end: { line: 3, character: 4 },
-            },
-            source: "source",
-            code: "test code",
-            severity: ls.DiagnosticSeverity.Information,
-          },
-        ],
-      })
-
-      const mockEditor = createFakeEditor(testPath)
-      expect(adapter.getDiagnosticCode(mockEditor, new Range([1, 2], [3, 4]), "Test message")).toBe("test code")
-      expect(adapter.getDiagnosticCode(mockEditor, new Range([1, 2], [3, 4]), "Test message2")).toBe(null)
-      expect(adapter.getDiagnosticCode(mockEditor, new Range([1, 2], [3, 5]), "Test message")).toBe(null)
     })
   })
 })

--- a/typings/atom/index.d.ts
+++ b/typings/atom/index.d.ts
@@ -27,3 +27,9 @@ declare module "atom/src/config" {
     get<T extends "atom-i18n.locale">(key: T): string
   }
 }
+
+declare module "atom/linter" {
+  interface Message {
+    key?: string
+  }
+}


### PR DESCRIPTION
- Moves the old atom-ide-diagnostics code to a separate adapter
- Adds initial code actions support for the Linter package -> The packages themselves have not implemented this yet