### PR TITLE
fix: add `LocationLink` support for definition-adapter

### DIFF
--- a/lib/adapters/definition-adapter.ts
+++ b/lib/adapters/definition-adapter.ts
@@ -107,6 +107,6 @@ export default class DefinitionAdapter {
     }))
   }
   private static isLocationLinkArray(value: any): value is LocationLink[] {
-    return Array.isArray(value) && LocationLink.is(value[0])
+    return Array.isArray(value) && value.every((v) => LocationLink.is(v))
   }
 }

--- a/lib/adapters/definition-adapter.ts
+++ b/lib/adapters/definition-adapter.ts
@@ -72,8 +72,10 @@ export default class DefinitionAdapter {
     locationResult: Location | Location[] | LocationLink[] | null
   ): Location[] | LocationLink[] | null {
     if (locationResult == null) {
+      // TODO use ===
       return null
     }
+    // TODO `d.targetRange.start` never becomes `null` according to the types
     if (isLocationLinkArray(locationResult)) {
       return locationResult.filter((d) => d.targetRange.start != null)
     }

--- a/lib/adapters/definition-adapter.ts
+++ b/lib/adapters/definition-adapter.ts
@@ -74,7 +74,7 @@ export default class DefinitionAdapter {
     if (locationResult == null) {
       return null
     }
-    if (this.isLocationLinkArray(locationResult)) {
+    if (isLocationLinkArray(locationResult)) {
       return locationResult.filter((d) => d.targetRange.start != null)
     }
     return (Array.isArray(locationResult) ? locationResult : [locationResult]).filter((d) => d.range.start != null)
@@ -91,7 +91,7 @@ export default class DefinitionAdapter {
     locations: Location[] | LocationLink[],
     languageName: string
   ): atomIde.Definition[] {
-    if (this.isLocationLinkArray(locations)) {
+    if (isLocationLinkArray(locations)) {
       return locations.map((d) => ({
         path: Convert.uriToPath(d.targetUri),
         position: Convert.positionToPoint(d.targetRange.start),
@@ -106,7 +106,8 @@ export default class DefinitionAdapter {
       language: languageName,
     }))
   }
-  private static isLocationLinkArray(value: any): value is LocationLink[] {
-    return Array.isArray(value) && value.every((v) => LocationLink.is(v))
-  }
+}
+
+function isLocationLinkArray(value: any): value is LocationLink[] {
+  return Array.isArray(value) && LocationLink.is(value[0])
 }

--- a/lib/adapters/definition-adapter.ts
+++ b/lib/adapters/definition-adapter.ts
@@ -68,11 +68,11 @@ export default class DefinitionAdapter {
    * @param locationResult Either a single {Location} object or an {Array} of {Locations}.
    * @returns An {Array} of {Location}s or {null} if the locationResult was null.
    */
-  public static normalizeLocations(locationResult: Location | Location[] | LocationLink[]): Location[] | LocationLink[] | null {
+  public static normalizeLocations(locationResult: Location | (Location | LocationLink)[]): (Location | LocationLink)[] | null {
     if (locationResult == null) {
       return null
     }
-    return (Array.isArray(locationResult) ? locationResult : [locationResult]).filter((d) => (d.range||d.targetRange).start != null)
+    return (Array.isArray(locationResult) ? locationResult : [locationResult]).filter((d) => ('range' in d?d.range:d.targetRange).start != null)
   }
 
   /**
@@ -82,11 +82,11 @@ export default class DefinitionAdapter {
    * @param languageName The name of the language these objects are written in.
    * @returns An {Array} of {Definition}s that represented the converted {Location}s.
    */
-  public static convertLocationsToDefinitions(locations: Location[] | LocationLink[], languageName: string): atomIde.Definition[] {
+  public static convertLocationsToDefinitions(locations: (Location | LocationLink)[], languageName: string): atomIde.Definition[] {
     return locations.map((d) => ({
-      path: Convert.uriToPath(d.uri||d.targetUri),
-      position: Convert.positionToPoint((d.range||d.targetRange).start),
-      range: Range.fromObject(Convert.lsRangeToAtomRange(d.range||d.targetRange)),
+      path: Convert.uriToPath('uri' in d?d.uri:d.targetUri),
+      position: Convert.positionToPoint(('range' in d?d.range:d.targetRange).start),
+      range: Range.fromObject(Convert.lsRangeToAtomRange('range' in d?d.range:d.targetRange)),
       language: languageName,
     }))
   }

--- a/lib/adapters/definition-adapter.ts
+++ b/lib/adapters/definition-adapter.ts
@@ -1,7 +1,7 @@
 import type * as atomIde from "atom-ide-base"
 import Convert from "../convert"
 import * as Utils from "../utils"
-import { LanguageClientConnection, Location, LocationLink, ServerCapabilities } from "../languageclient.ts"
+import { LanguageClientConnection, Location, LocationLink, ServerCapabilities } from "../languageclient"
 import { Point, TextEditor, Range } from "atom"
 
 /**

--- a/lib/adapters/definition-adapter.ts
+++ b/lib/adapters/definition-adapter.ts
@@ -1,7 +1,7 @@
 import type * as atomIde from "atom-ide-base"
 import Convert from "../convert"
 import * as Utils from "../utils"
-import { LanguageClientConnection, Location, ServerCapabilities } from "../languageclient"
+import { LanguageClientConnection, Location, LocationLink, ServerCapabilities } from "../languageclient.ts"
 import { Point, TextEditor, Range } from "atom"
 
 /**
@@ -68,11 +68,11 @@ export default class DefinitionAdapter {
    * @param locationResult Either a single {Location} object or an {Array} of {Locations}.
    * @returns An {Array} of {Location}s or {null} if the locationResult was null.
    */
-  public static normalizeLocations(locationResult: Location | Location[]): Location[] | null {
+  public static normalizeLocations(locationResult: Location | Location[] | LocationLink[]): Location[] | LocationLink[] | null {
     if (locationResult == null) {
       return null
     }
-    return (Array.isArray(locationResult) ? locationResult : [locationResult]).filter((d) => d.range.start != null)
+    return (Array.isArray(locationResult) ? locationResult : [locationResult]).filter((d) => (d.range||d.targetRange).start != null)
   }
 
   /**
@@ -82,11 +82,11 @@ export default class DefinitionAdapter {
    * @param languageName The name of the language these objects are written in.
    * @returns An {Array} of {Definition}s that represented the converted {Location}s.
    */
-  public static convertLocationsToDefinitions(locations: Location[], languageName: string): atomIde.Definition[] {
+  public static convertLocationsToDefinitions(locations: Location[] | LocationLink[], languageName: string): atomIde.Definition[] {
     return locations.map((d) => ({
-      path: Convert.uriToPath(d.uri),
-      position: Convert.positionToPoint(d.range.start),
-      range: Range.fromObject(Convert.lsRangeToAtomRange(d.range)),
+      path: Convert.uriToPath(d.uri||d.targetUri),
+      position: Convert.positionToPoint((d.range||d.targetRange).start),
+      range: Range.fromObject(Convert.lsRangeToAtomRange(d.range||d.targetRange)),
       language: languageName,
     }))
   }

--- a/lib/adapters/definition-adapter.ts
+++ b/lib/adapters/definition-adapter.ts
@@ -74,7 +74,7 @@ export default class DefinitionAdapter {
     if (locationResult == null) {
       return null
     }
-    return (Array.isArray(locationResult) ? locationResult as any[] : [locationResult]).filter(
+    return (Array.isArray(locationResult) ? (locationResult as any[]) : [locationResult]).filter(
       (d: Location | LocationLink) => ("range" in d ? d.range : d.targetRange).start != null
     )
   }

--- a/lib/adapters/definition-adapter.ts
+++ b/lib/adapters/definition-adapter.ts
@@ -69,13 +69,13 @@ export default class DefinitionAdapter {
    * @returns An {Array} of {Location}s or {null} if the locationResult was null.
    */
   public static normalizeLocations(
-    locationResult: Location | (Location | LocationLink)[]
-  ): (Location | LocationLink)[] | null {
+    locationResult: Location | Location[] | LocationLink[] | null
+  ): Location[] | LocationLink[] | null {
     if (locationResult == null) {
       return null
     }
-    return (Array.isArray(locationResult) ? locationResult : [locationResult]).filter(
-      (d) => ("range" in d ? d.range : d.targetRange).start != null
+    return (Array.isArray(locationResult) ? locationResult as any[] : [locationResult]).filter(
+      (d: Location | LocationLink) => ("range" in d ? d.range : d.targetRange).start != null
     )
   }
 
@@ -87,10 +87,10 @@ export default class DefinitionAdapter {
    * @returns An {Array} of {Definition}s that represented the converted {Location}s.
    */
   public static convertLocationsToDefinitions(
-    locations: (Location | LocationLink)[],
+    locations: Location[] | LocationLink[],
     languageName: string
   ): atomIde.Definition[] {
-    return locations.map((d) => ({
+    return (locations as any[]).map((d: Location | LocationLink) => ({
       path: Convert.uriToPath("uri" in d ? d.uri : d.targetUri),
       position: Convert.positionToPoint(("range" in d ? d.range : d.targetRange).start),
       range: Range.fromObject(Convert.lsRangeToAtomRange("range" in d ? d.range : d.targetRange)),

--- a/lib/adapters/definition-adapter.ts
+++ b/lib/adapters/definition-adapter.ts
@@ -68,11 +68,15 @@ export default class DefinitionAdapter {
    * @param locationResult Either a single {Location} object or an {Array} of {Locations}.
    * @returns An {Array} of {Location}s or {null} if the locationResult was null.
    */
-  public static normalizeLocations(locationResult: Location | (Location | LocationLink)[]): (Location | LocationLink)[] | null {
+  public static normalizeLocations(
+    locationResult: Location | (Location | LocationLink)[]
+  ): (Location | LocationLink)[] | null {
     if (locationResult == null) {
       return null
     }
-    return (Array.isArray(locationResult) ? locationResult : [locationResult]).filter((d) => ('range' in d?d.range:d.targetRange).start != null)
+    return (Array.isArray(locationResult) ? locationResult : [locationResult]).filter(
+      (d) => ("range" in d ? d.range : d.targetRange).start != null
+    )
   }
 
   /**
@@ -82,11 +86,14 @@ export default class DefinitionAdapter {
    * @param languageName The name of the language these objects are written in.
    * @returns An {Array} of {Definition}s that represented the converted {Location}s.
    */
-  public static convertLocationsToDefinitions(locations: (Location | LocationLink)[], languageName: string): atomIde.Definition[] {
+  public static convertLocationsToDefinitions(
+    locations: (Location | LocationLink)[],
+    languageName: string
+  ): atomIde.Definition[] {
     return locations.map((d) => ({
-      path: Convert.uriToPath('uri' in d?d.uri:d.targetUri),
-      position: Convert.positionToPoint(('range' in d?d.range:d.targetRange).start),
-      range: Range.fromObject(Convert.lsRangeToAtomRange('range' in d?d.range:d.targetRange)),
+      path: Convert.uriToPath("uri" in d ? d.uri : d.targetUri),
+      position: Convert.positionToPoint(("range" in d ? d.range : d.targetRange).start),
+      range: Range.fromObject(Convert.lsRangeToAtomRange("range" in d ? d.range : d.targetRange)),
       language: languageName,
     }))
   }

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -343,7 +343,9 @@ export class LanguageClientConnection extends EventEmitter {
    *   symbol are required.
    * @returns A {Promise} containing either a single {Location} or an {Array} of many {Location}s.
    */
-  public gotoDefinition(params: lsp.TextDocumentPositionParams): Promise<lsp.Location | lsp.Location[]> {
+  public gotoDefinition(
+    params: lsp.TextDocumentPositionParams
+  ): Promise<lsp.Location | lsp.Location[] | lsp.LocationLink[] | null> {
     return this._sendRequest("textDocument/definition", params)
   }
 


### PR DESCRIPTION
 According to https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_definition, the `textDocument/definition` request returns not only `Location[]` but also `LocationLink[]`. May I add support for this?

This is my first experience of TypeScript, so please let me know if I make any mistakes.