### PR TITLE
fix: set the correct fallback for Snippet completion

### DIFF
--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -492,7 +492,7 @@ export default class AutocompleteAdapter {
    */
   public static applySnippetToSuggestion(item: CompletionItem, suggestion: SnippetSuggestion): void {
     if (item.insertTextFormat === InsertTextFormat.Snippet) {
-      suggestion.snippet = item.textEdit != null ? item.textEdit.newText : item.insertText || ""
+      suggestion.snippet = item.textEdit != null ? item.textEdit.newText : item.insertText || item.label
     }
   }
 

--- a/test/adapters/autocomplete-adapter.test.ts
+++ b/test/adapters/autocomplete-adapter.test.ts
@@ -248,6 +248,11 @@ describe("AutoCompleteAdapter", () => {
           value: "documentation",
         },
       },
+      {
+        label: "sorawo",
+        sortText: "f",
+        insertTextFormat: ls.InsertTextFormat.Snippet,
+      },
     ]
 
     beforeEach(() => {
@@ -284,6 +289,9 @@ describe("AutoCompleteAdapter", () => {
       expect(results[4].description).is.undefined
       expect(results[4].descriptionMarkdown).equals("documentation")
       expect(results[4].rightLabel).equals("details")
+
+      expect(results[5].displayText).equals("sorawo")
+      expect((results[5] as SnippetSuggestion).snippet).equals("sorawo")
     })
 
     it("respects onDidConvertCompletionItem", async () => {


### PR DESCRIPTION
Currently, Snippets without `insertText` are not completed (empty strings are inserted).
According to the lsp `CompletionItem` spec, Implementation should fall back to `label`.
This pull request fixes it.

>https://microsoft.github.io/language-server-protocol/specification#textDocument_completion
>A string that should be inserted into a document when selecting this completion. When `falsy` the label is used as the insert text for this item.