### PR TITLE
Added null check to some adapters and changed type definition

### DIFF
--- a/lib/adapters/code-action-adapter.ts
+++ b/lib/adapters/code-action-adapter.ts
@@ -39,7 +39,7 @@ export default class CodeActionAdapter {
     editor: TextEditor,
     range: Range,
     diagnostics: atomIde.Diagnostic[]
-  ): Promise<atomIde.CodeAction[] | null> {
+  ): Promise<atomIde.CodeAction[]> {
     if (linterAdapter == null) {
       return []
     }
@@ -48,7 +48,7 @@ export default class CodeActionAdapter {
     const params = CodeActionAdapter.createCodeActionParams(linterAdapter, editor, range, diagnostics)
     const actions = await connection.codeAction(params)
     if (!actions) {
-      return null
+      return []
     }
     return actions.map((action) => CodeActionAdapter.createCodeAction(action, connection))
   }

--- a/lib/adapters/code-action-adapter.ts
+++ b/lib/adapters/code-action-adapter.ts
@@ -39,7 +39,7 @@ export default class CodeActionAdapter {
     editor: TextEditor,
     range: Range,
     diagnostics: atomIde.Diagnostic[]
-  ): Promise<atomIde.CodeAction[]> {
+  ): Promise<atomIde.CodeAction[] | null> {
     if (linterAdapter == null) {
       return []
     }
@@ -47,7 +47,10 @@ export default class CodeActionAdapter {
 
     const params = CodeActionAdapter.createCodeActionParams(linterAdapter, editor, range, diagnostics)
     const actions = await connection.codeAction(params)
-    return (actions || []).map((action) => CodeActionAdapter.createCodeAction(action, connection))
+    if (!actions) {
+      return null
+    }
+    return actions.map((action) => CodeActionAdapter.createCodeAction(action, connection))
   }
 
   private static createCodeAction(

--- a/lib/adapters/code-action-adapter.ts
+++ b/lib/adapters/code-action-adapter.ts
@@ -47,7 +47,7 @@ export default class CodeActionAdapter {
 
     const params = CodeActionAdapter.createCodeActionParams(linterAdapter, editor, range, diagnostics)
     const actions = await connection.codeAction(params)
-    return actions.map((action) => CodeActionAdapter.createCodeAction(action, connection))
+    return (actions||[]).map((action) => CodeActionAdapter.createCodeAction(action, connection))
   }
 
   private static createCodeAction(

--- a/lib/adapters/code-action-adapter.ts
+++ b/lib/adapters/code-action-adapter.ts
@@ -47,7 +47,7 @@ export default class CodeActionAdapter {
 
     const params = CodeActionAdapter.createCodeActionParams(linterAdapter, editor, range, diagnostics)
     const actions = await connection.codeAction(params)
-    return (actions||[]).map((action) => CodeActionAdapter.createCodeAction(action, connection))
+    return (actions || []).map((action) => CodeActionAdapter.createCodeAction(action, connection))
   }
 
   private static createCodeAction(

--- a/lib/adapters/code-action-adapter.ts
+++ b/lib/adapters/code-action-adapter.ts
@@ -47,7 +47,7 @@ export default class CodeActionAdapter {
 
     const params = CodeActionAdapter.createCodeActionParams(linterAdapter, editor, range, diagnostics)
     const actions = await connection.codeAction(params)
-    if (!actions) {
+    if (actions === null) {
       return []
     }
     return actions.map((action) => CodeActionAdapter.createCodeAction(action, connection))

--- a/lib/adapters/code-highlight-adapter.ts
+++ b/lib/adapters/code-highlight-adapter.ts
@@ -27,6 +27,7 @@ export default class CodeHighlightAdapter {
   ): Promise<Range[] | null> {
     assert(serverCapabilities.documentHighlightProvider, "Must have the documentHighlight capability")
     const highlights = await connection.documentHighlight(Convert.editorToTextDocumentPositionParams(editor, position))
+    if (!highlights) {return null}
     return highlights.map((highlight) => {
       return Convert.lsRangeToAtomRange(highlight.range)
     })

--- a/lib/adapters/code-highlight-adapter.ts
+++ b/lib/adapters/code-highlight-adapter.ts
@@ -27,7 +27,7 @@ export default class CodeHighlightAdapter {
   ): Promise<Range[]> {
     assert(serverCapabilities.documentHighlightProvider, "Must have the documentHighlight capability")
     const highlights = await connection.documentHighlight(Convert.editorToTextDocumentPositionParams(editor, position))
-    if (!highlights) {
+    if (highlights === null) {
       return []
     }
     return highlights.map((highlight) => {

--- a/lib/adapters/code-highlight-adapter.ts
+++ b/lib/adapters/code-highlight-adapter.ts
@@ -24,11 +24,11 @@ export default class CodeHighlightAdapter {
     serverCapabilities: ServerCapabilities,
     editor: TextEditor,
     position: Point
-  ): Promise<Range[] | null> {
+  ): Promise<Range[]> {
     assert(serverCapabilities.documentHighlightProvider, "Must have the documentHighlight capability")
     const highlights = await connection.documentHighlight(Convert.editorToTextDocumentPositionParams(editor, position))
     if (!highlights) {
-      return null
+      return []
     }
     return highlights.map((highlight) => {
       return Convert.lsRangeToAtomRange(highlight.range)

--- a/lib/adapters/code-highlight-adapter.ts
+++ b/lib/adapters/code-highlight-adapter.ts
@@ -27,7 +27,9 @@ export default class CodeHighlightAdapter {
   ): Promise<Range[] | null> {
     assert(serverCapabilities.documentHighlightProvider, "Must have the documentHighlight capability")
     const highlights = await connection.documentHighlight(Convert.editorToTextDocumentPositionParams(editor, position))
-    if (!highlights) {return null}
+    if (!highlights) {
+      return null
+    }
     return highlights.map((highlight) => {
       return Convert.lsRangeToAtomRange(highlight.range)
     })

--- a/lib/adapters/outline-view-adapter.ts
+++ b/lib/adapters/outline-view-adapter.ts
@@ -38,7 +38,7 @@ export default class OutlineViewAdapter {
       connection.documentSymbol({ textDocument: Convert.editorToTextDocumentIdentifier(editor) }, cancellationToken)
     )
 
-    if (results.length === 0) {
+    if (!results || results.length === 0) {
       return {
         outlineTrees: [],
       }

--- a/lib/adapters/outline-view-adapter.ts
+++ b/lib/adapters/outline-view-adapter.ts
@@ -38,7 +38,7 @@ export default class OutlineViewAdapter {
       connection.documentSymbol({ textDocument: Convert.editorToTextDocumentIdentifier(editor) }, cancellationToken)
     )
 
-    if (!results || results.length === 0) {
+    if (results === null || results.length === 0) {
       return {
         outlineTrees: [],
       }

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -935,7 +935,7 @@ export default class AutoLanguageClient {
    * `didChangeWatchedFiles` message filtering, override for custom logic.
    *
    * @param filePath Path of a file that has changed in the project path
-   * @returns  `false` => message will not be sent to the language server
+   * @returns `false` => message will not be sent to the language server
    */
   protected filterChangeWatchedFiles(_filePath: string): boolean {
     return true

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -343,9 +343,7 @@ export class LanguageClientConnection extends EventEmitter {
    *   symbol are required.
    * @returns A {Promise} containing either a single {Location} or an {Array} of many {Location}s.
    */
-  public gotoDefinition(
-    params: lsp.TextDocumentPositionParams
-  ) {
+  public gotoDefinition(params: lsp.TextDocumentPositionParams) {
     return this._sendRequest(lsp.DefinitionRequest.type, params)
   }
 
@@ -376,10 +374,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param cancellationToken The {CancellationToken} that is used to cancel this request if necessary.
    * @returns A {Promise} containing an {Array} of {SymbolInformation}s that can be used to navigate this document.
    */
-  public documentSymbol(
-    params: lsp.DocumentSymbolParams,
-    _cancellationToken?: jsonrpc.CancellationToken
-  ) {
+  public documentSymbol(params: lsp.DocumentSymbolParams, _cancellationToken?: jsonrpc.CancellationToken) {
     return this._sendRequest(lsp.DocumentSymbolRequest.type, params)
   }
 
@@ -525,7 +520,7 @@ export class LanguageClientConnection extends EventEmitter {
     protocol: lsp.ProtocolNotificationType<P, RO> | lsp.ProtocolNotificationType0<RO>,
     args?: P
   ): void {
-    const {method} = protocol
+    const { method } = protocol
     this._log.debug(`rpc.sendNotification ${method}`, args)
     this._rpc.sendNotification(method, args)
   }
@@ -535,7 +530,7 @@ export class LanguageClientConnection extends EventEmitter {
     args?: P,
     cancellationToken?: jsonrpc.CancellationToken
   ): Promise<R> {
-    const {method} = protocol
+    const { method } = protocol
     this._log.debug(`rpc.sendRequest ${method} sending`, args)
     try {
       const start = performance.now()

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -312,7 +312,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {CompletionItem} for which a fully resolved {CompletionItem} is desired.
    * @returns A {Promise} containing a fully resolved {CompletionItem}.
    */
-  public completionItemResolve(params: lsp.CompletionItem): Promise<lsp.CompletionItem | null> {
+  public completionItemResolve(params: lsp.CompletionItem): Promise<lsp.CompletionItem> {
     return this._sendRequest("completionItem/resolve", params)
   }
 
@@ -355,7 +355,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {TextDocumentPositionParams} of a symbol for which all referring {Location}s are desired.
    * @returns A {Promise} containing an {Array} of {Location}s that reference this symbol.
    */
-  public findReferences(params: lsp.ReferenceParams): Promise<lsp.Location[]> {
+  public findReferences(params: lsp.ReferenceParams): Promise<lsp.Location[] | null> {
     return this._sendRequest("textDocument/references", params)
   }
 
@@ -365,7 +365,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {TextDocumentPositionParams} of a symbol for which all highlights are desired.
    * @returns A {Promise} containing an {Array} of {DocumentHighlight}s that can be used to highlight this symbol.
    */
-  public documentHighlight(params: lsp.TextDocumentPositionParams): Promise<lsp.DocumentHighlight[]> {
+  public documentHighlight(params: lsp.TextDocumentPositionParams): Promise<lsp.DocumentHighlight[] | null> {
     return this._sendRequest("textDocument/documentHighlight", params)
   }
 
@@ -379,7 +379,7 @@ export class LanguageClientConnection extends EventEmitter {
   public documentSymbol(
     params: lsp.DocumentSymbolParams,
     _cancellationToken?: jsonrpc.CancellationToken
-  ): Promise<lsp.SymbolInformation[] | lsp.DocumentSymbol[]> {
+  ): Promise<lsp.SymbolInformation[] | lsp.DocumentSymbol[] | null> {
     return this._sendRequest("textDocument/documentSymbol", params)
   }
 
@@ -390,7 +390,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @returns A {Promise} containing an {Array} of {SymbolInformation}s that identify where the query string occurs
    *   within the workspace.
    */
-  public workspaceSymbol(params: lsp.WorkspaceSymbolParams): Promise<lsp.SymbolInformation[]> {
+  public workspaceSymbol(params: lsp.WorkspaceSymbolParams): Promise<lsp.SymbolInformation[] | null> {
     return this._sendRequest("workspace/symbol", params)
   }
 
@@ -400,7 +400,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {CodeActionParams} identifying the document, range and context for the code action.
    * @returns A {Promise} containing an {Array} of {Commands}s that can be performed against the given documents range.
    */
-  public codeAction(params: lsp.CodeActionParams): Promise<Array<lsp.Command | lsp.CodeAction>> {
+  public codeAction(params: lsp.CodeActionParams): Promise<Array<lsp.Command | lsp.CodeAction> | null> {
     return this._sendRequest("textDocument/codeAction", params)
   }
 
@@ -411,7 +411,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @returns A {Promise} containing an {Array} of {CodeLens}s that associate commands and data with specified ranges
    *   within the document.
    */
-  public codeLens(params: lsp.CodeLensParams): Promise<lsp.CodeLens[]> {
+  public codeLens(params: lsp.CodeLensParams): Promise<lsp.CodeLens[] | null> {
     return this._sendRequest("textDocument/codeLens", params)
   }
 
@@ -431,7 +431,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {DocumentLinkParams} identifying the document for which links should be identified.
    * @returns A {Promise} containing an {Array} of {DocumentLink}s relating uri's to specific ranges within the document.
    */
-  public documentLink(params: lsp.DocumentLinkParams): Promise<lsp.DocumentLink[]> {
+  public documentLink(params: lsp.DocumentLinkParams): Promise<lsp.DocumentLink[] | null> {
     return this._sendRequest("textDocument/documentLink", params)
   }
 
@@ -441,7 +441,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {DocumentLink} identifying the document link to be resolved with full detail.
    * @returns A {Promise} containing the {DocumentLink} fully resolved.
    */
-  public documentLinkResolve(params: lsp.DocumentLink): Promise<lsp.DocumentLink> {
+  public documentLinkResolve(params: lsp.DocumentLink): Promise<lsp.DocumentLink | null> {
     return this._sendRequest("documentLink/resolve", params)
   }
 
@@ -452,7 +452,7 @@ export class LanguageClientConnection extends EventEmitter {
    *   formatting preferences.
    * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the document to correctly reformat it.
    */
-  public documentFormatting(params: lsp.DocumentFormattingParams): Promise<lsp.TextEdit[]> {
+  public documentFormatting(params: lsp.DocumentFormattingParams): Promise<lsp.TextEdit[] | null> {
     return this._sendRequest("textDocument/formatting", params)
   }
 
@@ -463,7 +463,7 @@ export class LanguageClientConnection extends EventEmitter {
    *   additional formatting preferences.
    * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the document to correctly reformat it.
    */
-  public documentRangeFormatting(params: lsp.DocumentRangeFormattingParams): Promise<lsp.TextEdit[]> {
+  public documentRangeFormatting(params: lsp.DocumentRangeFormattingParams): Promise<lsp.TextEdit[] | null> {
     return this._sendRequest("textDocument/rangeFormatting", params)
   }
 
@@ -474,7 +474,7 @@ export class LanguageClientConnection extends EventEmitter {
    *   typed and at what position as well as additional formatting preferences.
    * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the document to correctly reformat it.
    */
-  public documentOnTypeFormatting(params: lsp.DocumentOnTypeFormattingParams): Promise<lsp.TextEdit[]> {
+  public documentOnTypeFormatting(params: lsp.DocumentOnTypeFormattingParams): Promise<lsp.TextEdit[] | null> {
     return this._sendRequest("textDocument/onTypeFormatting", params)
   }
 
@@ -486,7 +486,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @returns A {Promise} containing an {WorkspaceEdit} that contains a list of {TextEdit}s either on the changes
    *   property (keyed by uri) or the documentChanges property containing an {Array} of {TextDocumentEdit}s (preferred).
    */
-  public rename(params: lsp.RenameParams): Promise<lsp.WorkspaceEdit> {
+  public rename(params: lsp.RenameParams): Promise<lsp.WorkspaceEdit | null> {
     return this._sendRequest("textDocument/rename", params)
   }
 

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -539,7 +539,7 @@ export class LanguageClientConnection extends EventEmitter {
     this._log.debug(`rpc.sendRequest ${method} sending`, args)
     try {
       const start = performance.now()
-      let result
+      let result: R
       if (cancellationToken) {
         result = await this._rpc.sendRequest(method, args, cancellationToken)
       } else {
@@ -551,7 +551,7 @@ export class LanguageClientConnection extends EventEmitter {
 
       const took = performance.now() - start
       this._log.debug(`rpc.sendRequest ${method} received (${Math.floor(took)}ms)`, result)
-      return result as R
+      return result
     } catch (e) {
       const responseError = e as jsonrpc.ResponseError<any>
       if (cancellationToken && responseError.code === lsp.LSPErrorCodes.RequestCancelled) {

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -71,7 +71,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {InitializeParams} containing processId, rootPath, options and server capabilities.
    * @returns A {Promise} containing the {InitializeResult} with details of the server's capabilities.
    */
-  public initialize(params: lsp.InitializeParams) {
+  public initialize(params: lsp.InitializeParams): Promise<lsp.InitializeResult> {
     return this._sendRequest(lsp.InitializeRequest.type, params)
   }
 
@@ -81,7 +81,7 @@ export class LanguageClientConnection extends EventEmitter {
   }
 
   /** Public: Send a `shutdown` request to the language server. */
-  public shutdown() {
+  public shutdown(): Promise<void> {
     return this._sendRequest(lsp.ShutdownRequest.type)
   }
 
@@ -126,7 +126,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param method A string containing the name of the request message.
    * @param params The method's parameters
    */
-  public sendCustomRequest(method: string, params?: any[] | object) {
+  public sendCustomRequest(method: string, params?: any[] | object): Promise<any> {
     return this._sendRequest(new lsp.ProtocolRequestType<typeof params, any, any, void, any>(method), params)
   }
 
@@ -258,7 +258,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {WillSaveTextDocumentParams} containing the to-be-saved text document details and the reason for the save.
    * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the text document before it is saved.
    */
-  public willSaveWaitUntilTextDocument(params: lsp.WillSaveTextDocumentParams) {
+  public willSaveWaitUntilTextDocument(params: lsp.WillSaveTextDocumentParams): Promise<lsp.TextEdit[] | null> {
     return this._sendRequest(lsp.WillSaveTextDocumentWaitUntilRequest.type, params)
   }
 
@@ -301,7 +301,7 @@ export class LanguageClientConnection extends EventEmitter {
   public completion(
     params: lsp.TextDocumentPositionParams | CompletionParams,
     cancellationToken?: jsonrpc.CancellationToken
-  ) {
+  ): Promise<lsp.CompletionItem[] | lsp.CompletionList | null> {
     // Cancel prior request if necessary
     return this._sendRequest(lsp.CompletionRequest.type, params, cancellationToken)
   }
@@ -312,7 +312,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {CompletionItem} for which a fully resolved {CompletionItem} is desired.
    * @returns A {Promise} containing a fully resolved {CompletionItem}.
    */
-  public completionItemResolve(params: lsp.CompletionItem) {
+  public completionItemResolve(params: lsp.CompletionItem): Promise<lsp.CompletionItem> {
     return this._sendRequest(lsp.CompletionResolveRequest.type, params)
   }
 
@@ -322,7 +322,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {TextDocumentPositionParams} for which a {Hover} is desired.
    * @returns A {Promise} containing a {Hover}.
    */
-  public hover(params: lsp.TextDocumentPositionParams) {
+  public hover(params: lsp.TextDocumentPositionParams): Promise<lsp.Hover | null> {
     return this._sendRequest(lsp.HoverRequest.type, params)
   }
 
@@ -332,7 +332,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {TextDocumentPositionParams} for which a {SignatureHelp} is desired.
    * @returns A {Promise} containing a {SignatureHelp}.
    */
-  public signatureHelp(params: lsp.TextDocumentPositionParams) {
+  public signatureHelp(params: lsp.TextDocumentPositionParams): Promise<lsp.SignatureHelp | null> {
     return this._sendRequest(lsp.SignatureHelpRequest.type, params)
   }
 
@@ -343,7 +343,9 @@ export class LanguageClientConnection extends EventEmitter {
    *   symbol are required.
    * @returns A {Promise} containing either a single {Location} or an {Array} of many {Location}s.
    */
-  public gotoDefinition(params: lsp.TextDocumentPositionParams) {
+  public gotoDefinition(
+    params: lsp.TextDocumentPositionParams
+  ): Promise<lsp.Location | lsp.Location[] | lsp.LocationLink[] | null> {
     return this._sendRequest(lsp.DefinitionRequest.type, params)
   }
 
@@ -353,7 +355,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {TextDocumentPositionParams} of a symbol for which all referring {Location}s are desired.
    * @returns A {Promise} containing an {Array} of {Location}s that reference this symbol.
    */
-  public findReferences(params: lsp.ReferenceParams) {
+  public findReferences(params: lsp.ReferenceParams): Promise<lsp.Location[] | null> {
     return this._sendRequest(lsp.ReferencesRequest.type, params)
   }
 
@@ -363,7 +365,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {TextDocumentPositionParams} of a symbol for which all highlights are desired.
    * @returns A {Promise} containing an {Array} of {DocumentHighlight}s that can be used to highlight this symbol.
    */
-  public documentHighlight(params: lsp.TextDocumentPositionParams) {
+  public documentHighlight(params: lsp.TextDocumentPositionParams): Promise<lsp.DocumentHighlight[] | null> {
     return this._sendRequest(lsp.DocumentHighlightRequest.type, params)
   }
 
@@ -374,7 +376,10 @@ export class LanguageClientConnection extends EventEmitter {
    * @param cancellationToken The {CancellationToken} that is used to cancel this request if necessary.
    * @returns A {Promise} containing an {Array} of {SymbolInformation}s that can be used to navigate this document.
    */
-  public documentSymbol(params: lsp.DocumentSymbolParams, _cancellationToken?: jsonrpc.CancellationToken) {
+  public documentSymbol(
+    params: lsp.DocumentSymbolParams,
+    _cancellationToken?: jsonrpc.CancellationToken
+  ): Promise<lsp.SymbolInformation[] | lsp.DocumentSymbol[] | null> {
     return this._sendRequest(lsp.DocumentSymbolRequest.type, params)
   }
 
@@ -385,7 +390,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @returns A {Promise} containing an {Array} of {SymbolInformation}s that identify where the query string occurs
    *   within the workspace.
    */
-  public workspaceSymbol(params: lsp.WorkspaceSymbolParams) {
+  public workspaceSymbol(params: lsp.WorkspaceSymbolParams): Promise<lsp.SymbolInformation[] | null> {
     return this._sendRequest(lsp.WorkspaceSymbolRequest.type, params)
   }
 
@@ -395,7 +400,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {CodeActionParams} identifying the document, range and context for the code action.
    * @returns A {Promise} containing an {Array} of {Commands}s that can be performed against the given documents range.
    */
-  public codeAction(params: lsp.CodeActionParams) {
+  public codeAction(params: lsp.CodeActionParams): Promise<Array<lsp.Command | lsp.CodeAction> | null> {
     return this._sendRequest(lsp.CodeActionRequest.type, params)
   }
 
@@ -406,7 +411,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @returns A {Promise} containing an {Array} of {CodeLens}s that associate commands and data with specified ranges
    *   within the document.
    */
-  public codeLens(params: lsp.CodeLensParams) {
+  public codeLens(params: lsp.CodeLensParams): Promise<lsp.CodeLens[] | null> {
     return this._sendRequest(lsp.CodeLensRequest.type, params)
   }
 
@@ -416,7 +421,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {CodeLens} identifying the code lens to be resolved with full detail.
    * @returns A {Promise} containing the {CodeLens} fully resolved.
    */
-  public codeLensResolve(params: lsp.CodeLens) {
+  public codeLensResolve(params: lsp.CodeLens): Promise<lsp.CodeLens> {
     return this._sendRequest(lsp.CodeLensResolveRequest.type, params)
   }
 
@@ -426,7 +431,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {DocumentLinkParams} identifying the document for which links should be identified.
    * @returns A {Promise} containing an {Array} of {DocumentLink}s relating uri's to specific ranges within the document.
    */
-  public documentLink(params: lsp.DocumentLinkParams) {
+  public documentLink(params: lsp.DocumentLinkParams): Promise<lsp.DocumentLink[] | null> {
     return this._sendRequest(lsp.DocumentLinkRequest.type, params)
   }
 
@@ -436,7 +441,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {DocumentLink} identifying the document link to be resolved with full detail.
    * @returns A {Promise} containing the {DocumentLink} fully resolved.
    */
-  public documentLinkResolve(params: lsp.DocumentLink) {
+  public documentLinkResolve(params: lsp.DocumentLink): Promise<lsp.DocumentLink> {
     return this._sendRequest(lsp.DocumentLinkResolveRequest.type, params)
   }
 
@@ -447,7 +452,7 @@ export class LanguageClientConnection extends EventEmitter {
    *   formatting preferences.
    * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the document to correctly reformat it.
    */
-  public documentFormatting(params: lsp.DocumentFormattingParams) {
+  public documentFormatting(params: lsp.DocumentFormattingParams): Promise<lsp.TextEdit[] | null> {
     return this._sendRequest(lsp.DocumentFormattingRequest.type, params)
   }
 
@@ -458,7 +463,7 @@ export class LanguageClientConnection extends EventEmitter {
    *   additional formatting preferences.
    * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the document to correctly reformat it.
    */
-  public documentRangeFormatting(params: lsp.DocumentRangeFormattingParams) {
+  public documentRangeFormatting(params: lsp.DocumentRangeFormattingParams): Promise<lsp.TextEdit[] | null> {
     return this._sendRequest(lsp.DocumentRangeFormattingRequest.type, params)
   }
 
@@ -469,7 +474,7 @@ export class LanguageClientConnection extends EventEmitter {
    *   typed and at what position as well as additional formatting preferences.
    * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the document to correctly reformat it.
    */
-  public documentOnTypeFormatting(params: lsp.DocumentOnTypeFormattingParams) {
+  public documentOnTypeFormatting(params: lsp.DocumentOnTypeFormattingParams): Promise<lsp.TextEdit[] | null> {
     return this._sendRequest(lsp.DocumentOnTypeFormattingRequest.type, params)
   }
 
@@ -481,7 +486,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @returns A {Promise} containing an {WorkspaceEdit} that contains a list of {TextEdit}s either on the changes
    *   property (keyed by uri) or the documentChanges property containing an {Array} of {TextDocumentEdit}s (preferred).
    */
-  public rename(params: lsp.RenameParams) {
+  public rename(params: lsp.RenameParams): Promise<lsp.WorkspaceEdit | null> {
     return this._sendRequest(lsp.RenameRequest.type, params)
   }
 
@@ -492,7 +497,7 @@ export class LanguageClientConnection extends EventEmitter {
    *   (these commands are usually from {CodeLens} or {CodeAction} responses).
    * @returns A {Promise} containing anything.
    */
-  public executeCommand(params: lsp.ExecuteCommandParams) {
+  public executeCommand(params: lsp.ExecuteCommandParams): Promise<any> {
     return this._sendRequest(lsp.ExecuteCommandRequest.type, params)
   }
 

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -71,23 +71,23 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {InitializeParams} containing processId, rootPath, options and server capabilities.
    * @returns A {Promise} containing the {InitializeResult} with details of the server's capabilities.
    */
-  public initialize(params: lsp.InitializeParams): Promise<lsp.InitializeResult> {
-    return this._sendRequest("initialize", params)
+  public initialize(params: lsp.InitializeParams) {
+    return this._sendRequest(lsp.InitializeRequest.type, params)
   }
 
   /** Public: Send an `initialized` notification to the language server. */
   public initialized(): void {
-    this._sendNotification("initialized", {})
+    this._sendNotification(lsp.InitializedNotification.type, {})
   }
 
   /** Public: Send a `shutdown` request to the language server. */
-  public shutdown(): Promise<void> {
-    return this._sendRequest("shutdown")
+  public shutdown() {
+    return this._sendRequest(lsp.ShutdownRequest.type)
   }
 
   /** Public: Send an `exit` notification to the language server. */
   public exit(): void {
-    this._sendNotification("exit")
+    this._sendNotification(lsp.ExitNotification.type)
   }
 
   /**
@@ -126,8 +126,8 @@ export class LanguageClientConnection extends EventEmitter {
    * @param method A string containing the name of the request message.
    * @param params The method's parameters
    */
-  public sendCustomRequest(method: string, params?: any[] | object): Promise<any | null> {
-    return this._sendRequest(method, params)
+  public sendCustomRequest(method: string, params?: any[] | object) {
+    return this._sendRequest(new lsp.ProtocolRequestType<typeof params, any, any, void, any>(method), params)
   }
 
   /**
@@ -137,7 +137,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The method's parameters
    */
   public sendCustomNotification(method: string, params?: any[] | object): void {
-    this._sendNotification(method, params)
+    this._sendNotification(new lsp.ProtocolNotificationType<typeof params, any>(method), params)
   }
 
   /**
@@ -212,7 +212,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {DidChangeConfigurationParams} containing the new configuration.
    */
   public didChangeConfiguration(params: lsp.DidChangeConfigurationParams): void {
-    this._sendNotification("workspace/didChangeConfiguration", params)
+    this._sendNotification(lsp.DidChangeConfigurationNotification.type, params)
   }
 
   /**
@@ -221,7 +221,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {DidOpenTextDocumentParams} containing the opened text document details.
    */
   public didOpenTextDocument(params: lsp.DidOpenTextDocumentParams): void {
-    this._sendNotification("textDocument/didOpen", params)
+    this._sendNotification(lsp.DidOpenTextDocumentNotification.type, params)
   }
 
   /**
@@ -231,7 +231,7 @@ export class LanguageClientConnection extends EventEmitter {
    *   number and actual text changes.
    */
   public didChangeTextDocument(params: lsp.DidChangeTextDocumentParams): void {
-    this._sendNotification("textDocument/didChange", params)
+    this._sendNotification(lsp.DidChangeTextDocumentNotification.type, params)
   }
 
   /**
@@ -240,7 +240,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {DidCloseTextDocumentParams} containing the opened text document details.
    */
   public didCloseTextDocument(params: lsp.DidCloseTextDocumentParams): void {
-    this._sendNotification("textDocument/didClose", params)
+    this._sendNotification(lsp.DidCloseTextDocumentNotification.type, params)
   }
 
   /**
@@ -249,7 +249,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {WillSaveTextDocumentParams} containing the to-be-saved text document details and the reason for the save.
    */
   public willSaveTextDocument(params: lsp.WillSaveTextDocumentParams): void {
-    this._sendNotification("textDocument/willSave", params)
+    this._sendNotification(lsp.WillSaveTextDocumentNotification.type, params)
   }
 
   /**
@@ -258,8 +258,8 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {WillSaveTextDocumentParams} containing the to-be-saved text document details and the reason for the save.
    * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the text document before it is saved.
    */
-  public willSaveWaitUntilTextDocument(params: lsp.WillSaveTextDocumentParams): Promise<lsp.TextEdit[] | null> {
-    return this._sendRequest("textDocument/willSaveWaitUntil", params)
+  public willSaveWaitUntilTextDocument(params: lsp.WillSaveTextDocumentParams) {
+    return this._sendRequest(lsp.WillSaveTextDocumentWaitUntilRequest.type, params)
   }
 
   /**
@@ -268,7 +268,7 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {DidSaveTextDocumentParams} containing the saved text document details.
    */
   public didSaveTextDocument(params: lsp.DidSaveTextDocumentParams): void {
-    this._sendNotification("textDocument/didSave", params)
+    this._sendNotification(lsp.DidSaveTextDocumentNotification.type, params)
   }
 
   /**
@@ -278,7 +278,7 @@ export class LanguageClientConnection extends EventEmitter {
    *   the watched files.
    */
   public didChangeWatchedFiles(params: lsp.DidChangeWatchedFilesParams): void {
-    this._sendNotification("workspace/didChangeWatchedFiles", params)
+    this._sendNotification(lsp.DidChangeWatchedFilesNotification.type, params)
   }
 
   /**
@@ -301,9 +301,9 @@ export class LanguageClientConnection extends EventEmitter {
   public completion(
     params: lsp.TextDocumentPositionParams | CompletionParams,
     cancellationToken?: jsonrpc.CancellationToken
-  ): Promise<lsp.CompletionItem[] | lsp.CompletionList | null> {
+  ) {
     // Cancel prior request if necessary
-    return this._sendRequest("textDocument/completion", params, cancellationToken)
+    return this._sendRequest(lsp.CompletionRequest.type, params, cancellationToken)
   }
 
   /**
@@ -312,8 +312,8 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {CompletionItem} for which a fully resolved {CompletionItem} is desired.
    * @returns A {Promise} containing a fully resolved {CompletionItem}.
    */
-  public completionItemResolve(params: lsp.CompletionItem): Promise<lsp.CompletionItem> {
-    return this._sendRequest("completionItem/resolve", params)
+  public completionItemResolve(params: lsp.CompletionItem) {
+    return this._sendRequest(lsp.CompletionResolveRequest.type, params)
   }
 
   /**
@@ -322,8 +322,8 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {TextDocumentPositionParams} for which a {Hover} is desired.
    * @returns A {Promise} containing a {Hover}.
    */
-  public hover(params: lsp.TextDocumentPositionParams): Promise<lsp.Hover | null> {
-    return this._sendRequest("textDocument/hover", params)
+  public hover(params: lsp.TextDocumentPositionParams) {
+    return this._sendRequest(lsp.HoverRequest.type, params)
   }
 
   /**
@@ -332,8 +332,8 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {TextDocumentPositionParams} for which a {SignatureHelp} is desired.
    * @returns A {Promise} containing a {SignatureHelp}.
    */
-  public signatureHelp(params: lsp.TextDocumentPositionParams): Promise<lsp.SignatureHelp | null> {
-    return this._sendRequest("textDocument/signatureHelp", params)
+  public signatureHelp(params: lsp.TextDocumentPositionParams) {
+    return this._sendRequest(lsp.SignatureHelpRequest.type, params)
   }
 
   /**
@@ -345,8 +345,8 @@ export class LanguageClientConnection extends EventEmitter {
    */
   public gotoDefinition(
     params: lsp.TextDocumentPositionParams
-  ): Promise<lsp.Location | lsp.Location[] | lsp.LocationLink[] | null> {
-    return this._sendRequest("textDocument/definition", params)
+  ) {
+    return this._sendRequest(lsp.DefinitionRequest.type, params)
   }
 
   /**
@@ -355,8 +355,8 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {TextDocumentPositionParams} of a symbol for which all referring {Location}s are desired.
    * @returns A {Promise} containing an {Array} of {Location}s that reference this symbol.
    */
-  public findReferences(params: lsp.ReferenceParams): Promise<lsp.Location[] | null> {
-    return this._sendRequest("textDocument/references", params)
+  public findReferences(params: lsp.ReferenceParams) {
+    return this._sendRequest(lsp.ReferencesRequest.type, params)
   }
 
   /**
@@ -365,8 +365,8 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {TextDocumentPositionParams} of a symbol for which all highlights are desired.
    * @returns A {Promise} containing an {Array} of {DocumentHighlight}s that can be used to highlight this symbol.
    */
-  public documentHighlight(params: lsp.TextDocumentPositionParams): Promise<lsp.DocumentHighlight[] | null> {
-    return this._sendRequest("textDocument/documentHighlight", params)
+  public documentHighlight(params: lsp.TextDocumentPositionParams) {
+    return this._sendRequest(lsp.DocumentHighlightRequest.type, params)
   }
 
   /**
@@ -379,8 +379,8 @@ export class LanguageClientConnection extends EventEmitter {
   public documentSymbol(
     params: lsp.DocumentSymbolParams,
     _cancellationToken?: jsonrpc.CancellationToken
-  ): Promise<lsp.SymbolInformation[] | lsp.DocumentSymbol[] | null> {
-    return this._sendRequest("textDocument/documentSymbol", params)
+  ) {
+    return this._sendRequest(lsp.DocumentSymbolRequest.type, params)
   }
 
   /**
@@ -390,8 +390,8 @@ export class LanguageClientConnection extends EventEmitter {
    * @returns A {Promise} containing an {Array} of {SymbolInformation}s that identify where the query string occurs
    *   within the workspace.
    */
-  public workspaceSymbol(params: lsp.WorkspaceSymbolParams): Promise<lsp.SymbolInformation[] | null> {
-    return this._sendRequest("workspace/symbol", params)
+  public workspaceSymbol(params: lsp.WorkspaceSymbolParams) {
+    return this._sendRequest(lsp.WorkspaceSymbolRequest.type, params)
   }
 
   /**
@@ -400,8 +400,8 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {CodeActionParams} identifying the document, range and context for the code action.
    * @returns A {Promise} containing an {Array} of {Commands}s that can be performed against the given documents range.
    */
-  public codeAction(params: lsp.CodeActionParams): Promise<Array<lsp.Command | lsp.CodeAction> | null> {
-    return this._sendRequest("textDocument/codeAction", params)
+  public codeAction(params: lsp.CodeActionParams) {
+    return this._sendRequest(lsp.CodeActionRequest.type, params)
   }
 
   /**
@@ -411,8 +411,8 @@ export class LanguageClientConnection extends EventEmitter {
    * @returns A {Promise} containing an {Array} of {CodeLens}s that associate commands and data with specified ranges
    *   within the document.
    */
-  public codeLens(params: lsp.CodeLensParams): Promise<lsp.CodeLens[] | null> {
-    return this._sendRequest("textDocument/codeLens", params)
+  public codeLens(params: lsp.CodeLensParams) {
+    return this._sendRequest(lsp.CodeLensRequest.type, params)
   }
 
   /**
@@ -421,8 +421,8 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {CodeLens} identifying the code lens to be resolved with full detail.
    * @returns A {Promise} containing the {CodeLens} fully resolved.
    */
-  public codeLensResolve(params: lsp.CodeLens): Promise<lsp.CodeLens | null> {
-    return this._sendRequest("codeLens/resolve", params)
+  public codeLensResolve(params: lsp.CodeLens) {
+    return this._sendRequest(lsp.CodeLensResolveRequest.type, params)
   }
 
   /**
@@ -431,8 +431,8 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {DocumentLinkParams} identifying the document for which links should be identified.
    * @returns A {Promise} containing an {Array} of {DocumentLink}s relating uri's to specific ranges within the document.
    */
-  public documentLink(params: lsp.DocumentLinkParams): Promise<lsp.DocumentLink[] | null> {
-    return this._sendRequest("textDocument/documentLink", params)
+  public documentLink(params: lsp.DocumentLinkParams) {
+    return this._sendRequest(lsp.DocumentLinkRequest.type, params)
   }
 
   /**
@@ -441,8 +441,8 @@ export class LanguageClientConnection extends EventEmitter {
    * @param params The {DocumentLink} identifying the document link to be resolved with full detail.
    * @returns A {Promise} containing the {DocumentLink} fully resolved.
    */
-  public documentLinkResolve(params: lsp.DocumentLink): Promise<lsp.DocumentLink | null> {
-    return this._sendRequest("documentLink/resolve", params)
+  public documentLinkResolve(params: lsp.DocumentLink) {
+    return this._sendRequest(lsp.DocumentLinkResolveRequest.type, params)
   }
 
   /**
@@ -452,8 +452,8 @@ export class LanguageClientConnection extends EventEmitter {
    *   formatting preferences.
    * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the document to correctly reformat it.
    */
-  public documentFormatting(params: lsp.DocumentFormattingParams): Promise<lsp.TextEdit[] | null> {
-    return this._sendRequest("textDocument/formatting", params)
+  public documentFormatting(params: lsp.DocumentFormattingParams) {
+    return this._sendRequest(lsp.DocumentFormattingRequest.type, params)
   }
 
   /**
@@ -463,8 +463,8 @@ export class LanguageClientConnection extends EventEmitter {
    *   additional formatting preferences.
    * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the document to correctly reformat it.
    */
-  public documentRangeFormatting(params: lsp.DocumentRangeFormattingParams): Promise<lsp.TextEdit[] | null> {
-    return this._sendRequest("textDocument/rangeFormatting", params)
+  public documentRangeFormatting(params: lsp.DocumentRangeFormattingParams) {
+    return this._sendRequest(lsp.DocumentRangeFormattingRequest.type, params)
   }
 
   /**
@@ -474,8 +474,8 @@ export class LanguageClientConnection extends EventEmitter {
    *   typed and at what position as well as additional formatting preferences.
    * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the document to correctly reformat it.
    */
-  public documentOnTypeFormatting(params: lsp.DocumentOnTypeFormattingParams): Promise<lsp.TextEdit[] | null> {
-    return this._sendRequest("textDocument/onTypeFormatting", params)
+  public documentOnTypeFormatting(params: lsp.DocumentOnTypeFormattingParams) {
+    return this._sendRequest(lsp.DocumentOnTypeFormattingRequest.type, params)
   }
 
   /**
@@ -486,8 +486,8 @@ export class LanguageClientConnection extends EventEmitter {
    * @returns A {Promise} containing an {WorkspaceEdit} that contains a list of {TextEdit}s either on the changes
    *   property (keyed by uri) or the documentChanges property containing an {Array} of {TextDocumentEdit}s (preferred).
    */
-  public rename(params: lsp.RenameParams): Promise<lsp.WorkspaceEdit | null> {
-    return this._sendRequest("textDocument/rename", params)
+  public rename(params: lsp.RenameParams) {
+    return this._sendRequest(lsp.RenameRequest.type, params)
   }
 
   /**
@@ -497,8 +497,8 @@ export class LanguageClientConnection extends EventEmitter {
    *   (these commands are usually from {CodeLens} or {CodeAction} responses).
    * @returns A {Promise} containing anything.
    */
-  public executeCommand(params: lsp.ExecuteCommandParams): Promise<any> {
-    return this._sendRequest("workspace/executeCommand", params)
+  public executeCommand(params: lsp.ExecuteCommandParams) {
+    return this._sendRequest(lsp.ExecuteCommandRequest.type, params)
   }
 
   private _onRequest<T extends Extract<keyof KnownRequests, string>>(
@@ -521,16 +521,21 @@ export class LanguageClientConnection extends EventEmitter {
     })
   }
 
-  private _sendNotification(method: string, args?: object): void {
+  private _sendNotification<P, RO>(
+    protocol: lsp.ProtocolNotificationType<P, RO> | lsp.ProtocolNotificationType0<RO>,
+    args?: P
+  ): void {
+    const {method} = protocol
     this._log.debug(`rpc.sendNotification ${method}`, args)
     this._rpc.sendNotification(method, args)
   }
 
-  private async _sendRequest(
-    method: string,
-    args?: object,
+  private async _sendRequest<P, R, PR, E, RO>(
+    protocol: lsp.ProtocolRequestType<P, R, PR, E, RO> | lsp.ProtocolRequestType0<R, PR, E, RO>,
+    args?: P,
     cancellationToken?: jsonrpc.CancellationToken
-  ): Promise<any> {
+  ): Promise<R> {
+    const {method} = protocol
     this._log.debug(`rpc.sendRequest ${method} sending`, args)
     try {
       const start = performance.now()
@@ -546,7 +551,7 @@ export class LanguageClientConnection extends EventEmitter {
 
       const took = performance.now() - start
       this._log.debug(`rpc.sendRequest ${method} received (${Math.floor(took)}ms)`, result)
-      return result
+      return result as R
     } catch (e) {
       const responseError = e as jsonrpc.ResponseError<any>
       if (cancellationToken && responseError.code === lsp.LSPErrorCodes.RequestCancelled) {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-chai-friendly": "^0.6.0",
     "mocha": "^8.3.2",
     "mocha-appveyor-reporter": "^0.4.2",
-    "prettier-config-atomic": "^2.0.2",
+    "prettier-config-atomic": "^2.0.3",
     "shx": "^0.3.3",
     "sinon": "^10.0.0",
     "typescript": "~4.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ specifiers:
   eslint-plugin-chai-friendly: ^0.6.0
   mocha: ^8.3.2
   mocha-appveyor-reporter: ^0.4.2
-  prettier-config-atomic: ^2.0.2
+  prettier-config-atomic: ^2.0.3
   rimraf: ^3.0.2
   shx: ^0.3.3
   sinon: ^10.0.0
@@ -45,7 +45,7 @@ devDependencies:
   eslint-plugin-chai-friendly: 0.6.0
   mocha: 8.3.2
   mocha-appveyor-reporter: 0.4.2
-  prettier-config-atomic: 2.0.2
+  prettier-config-atomic: 2.0.3
   shx: 0.3.3
   sinon: 10.0.0
   typescript: 4.2.4
@@ -3008,17 +3008,17 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-config-atomic/2.0.2:
-    resolution: {integrity: sha512-wnDfuHUKZrtsR4iOnDax2Ty6VgKueqIs9Xbl0s8ci1Aap0RI/UH/2hNWnUjn2EVeMsufpAO9ezq8LdZtgAnmEQ==}
+  /prettier-config-atomic/2.0.3:
+    resolution: {integrity: sha512-t4ILoW9A6JrzPA64XtXcLxZ1DrsEh/7RuKblGrqy7aEBXbHOjBLfaIeOcQa1dRgZc9gphwB65FZxhcN9HfXBRw==}
     dependencies:
       prettier: 2.2.1
-      prettier-plugin-jsdoc: 0.3.19_prettier@2.2.1
+      prettier-plugin-jsdoc: 0.3.21_prettier@2.2.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /prettier-plugin-jsdoc/0.3.19_prettier@2.2.1:
-    resolution: {integrity: sha512-pkzQSmQX9tXGScRGjXC1eV9YZ+Ze0nsZwRaFQ6T0pLzeopOJ+fkEapNiA5PK+3DLezZMzwPMAb2dB5fCqHItbQ==}
+  /prettier-plugin-jsdoc/0.3.21_prettier@2.2.1:
+    resolution: {integrity: sha512-QiYtjym/lcpbwgGERfvwd7z73GW2NNEpfz0EwiqnPtYM3xrxbskuD7oquLKrRmEuN0DhiWomXFwIBquE26Rjrw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       prettier: '>=2.1.2'

--- a/test/adapters/code-action-adapter.test.ts
+++ b/test/adapters/code-action-adapter.test.ts
@@ -75,8 +75,8 @@ describe("CodeActionAdapter", () => {
         },
       ])
 
-      expect((actions as any).length).to.equal(1)
-      const codeAction = (actions as any)[0]
+      expect(actions.length).to.equal(1)
+      const codeAction = actions[0]
       expect(await codeAction.getTitle()).to.equal("Test Command")
       await codeAction.apply()
       expect((languageClient as any).executeCommand.called).to.be.true

--- a/test/adapters/code-action-adapter.test.ts
+++ b/test/adapters/code-action-adapter.test.ts
@@ -75,8 +75,8 @@ describe("CodeActionAdapter", () => {
         },
       ])
 
-      expect(actions.length).to.equal(1)
-      const codeAction = actions[0]
+      expect((actions as any).length).to.equal(1)
+      const codeAction = (actions as any)[0]
       expect(await codeAction.getTitle()).to.equal("Test Command")
       await codeAction.apply()
       expect((languageClient as any).executeCommand.called).to.be.true

--- a/test/languageclient.test.ts
+++ b/test/languageclient.test.ts
@@ -37,7 +37,7 @@ describe("LanguageClientConnection", () => {
       await lc.initialize(params)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("initialize")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("initialize")
       expect(lc._sendRequest.getCall(0).args[1]).equals(params)
     })
 
@@ -45,14 +45,14 @@ describe("LanguageClientConnection", () => {
       await lc.shutdown()
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("shutdown")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("shutdown")
     })
 
     it("sends a request for completion", async () => {
       await lc.completion(textDocumentPositionParams)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("textDocument/completion")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("textDocument/completion")
       expect(lc._sendRequest.getCall(0).args[1]).equals(textDocumentPositionParams)
     })
 
@@ -61,7 +61,7 @@ describe("LanguageClientConnection", () => {
       await lc.completionItemResolve(completionItem)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("completionItem/resolve")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("completionItem/resolve")
       expect(lc._sendRequest.getCall(0).args[1]).equals(completionItem)
     })
 
@@ -69,7 +69,7 @@ describe("LanguageClientConnection", () => {
       await lc.hover(textDocumentPositionParams)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("textDocument/hover")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("textDocument/hover")
       expect(lc._sendRequest.getCall(0).args[1]).equals(textDocumentPositionParams)
     })
 
@@ -77,7 +77,7 @@ describe("LanguageClientConnection", () => {
       await lc.signatureHelp(textDocumentPositionParams)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("textDocument/signatureHelp")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("textDocument/signatureHelp")
       expect(lc._sendRequest.getCall(0).args[1]).equals(textDocumentPositionParams)
     })
 
@@ -85,7 +85,7 @@ describe("LanguageClientConnection", () => {
       await lc.gotoDefinition(textDocumentPositionParams)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("textDocument/definition")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("textDocument/definition")
       expect(lc._sendRequest.getCall(0).args[1]).equals(textDocumentPositionParams)
     })
 
@@ -93,7 +93,7 @@ describe("LanguageClientConnection", () => {
       await lc.findReferences(textDocumentPositionParams)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("textDocument/references")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("textDocument/references")
       expect(lc._sendRequest.getCall(0).args[1]).equals(textDocumentPositionParams)
     })
 
@@ -101,7 +101,7 @@ describe("LanguageClientConnection", () => {
       await lc.documentHighlight(textDocumentPositionParams)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("textDocument/documentHighlight")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("textDocument/documentHighlight")
       expect(lc._sendRequest.getCall(0).args[1]).equals(textDocumentPositionParams)
     })
 
@@ -109,7 +109,7 @@ describe("LanguageClientConnection", () => {
       await lc.documentSymbol(textDocumentPositionParams)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("textDocument/documentSymbol")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("textDocument/documentSymbol")
       expect(lc._sendRequest.getCall(0).args[1]).equals(textDocumentPositionParams)
     })
 
@@ -118,7 +118,7 @@ describe("LanguageClientConnection", () => {
       await lc.workspaceSymbol(params)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("workspace/symbol")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("workspace/symbol")
       expect(lc._sendRequest.getCall(0).args[1]).equals(params)
     })
 
@@ -134,7 +134,7 @@ describe("LanguageClientConnection", () => {
       await lc.codeAction(params)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("textDocument/codeAction")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("textDocument/codeAction")
       expect(lc._sendRequest.getCall(0).args[1]).equals(params)
     })
 
@@ -145,7 +145,7 @@ describe("LanguageClientConnection", () => {
       await lc.codeLens(params)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("textDocument/codeLens")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("textDocument/codeLens")
       expect(lc._sendRequest.getCall(0).args[1]).equals(params)
     })
 
@@ -159,7 +159,7 @@ describe("LanguageClientConnection", () => {
       await lc.codeLensResolve(params)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("codeLens/resolve")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("codeLens/resolve")
       expect(lc._sendRequest.getCall(0).args[1]).equals(params)
     })
 
@@ -170,7 +170,7 @@ describe("LanguageClientConnection", () => {
       await lc.documentLink(params)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("textDocument/documentLink")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("textDocument/documentLink")
       expect(lc._sendRequest.getCall(0).args[1]).equals(params)
     })
 
@@ -185,7 +185,7 @@ describe("LanguageClientConnection", () => {
       await lc.documentLinkResolve(params)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("documentLink/resolve")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("documentLink/resolve")
       expect(lc._sendRequest.getCall(0).args[1]).equals(params)
     })
 
@@ -197,7 +197,7 @@ describe("LanguageClientConnection", () => {
       await lc.documentFormatting(params)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("textDocument/formatting")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("textDocument/formatting")
       expect(lc._sendRequest.getCall(0).args[1]).equals(params)
     })
 
@@ -213,7 +213,7 @@ describe("LanguageClientConnection", () => {
       await lc.documentRangeFormatting(params)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("textDocument/rangeFormatting")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("textDocument/rangeFormatting")
       expect(lc._sendRequest.getCall(0).args[1]).equals(params)
     })
 
@@ -227,7 +227,7 @@ describe("LanguageClientConnection", () => {
       await lc.documentOnTypeFormatting(params)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("textDocument/onTypeFormatting")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("textDocument/onTypeFormatting")
       expect(lc._sendRequest.getCall(0).args[1]).equals(params)
     })
 
@@ -240,7 +240,7 @@ describe("LanguageClientConnection", () => {
       await lc.rename(params)
 
       expect(lc._sendRequest.called).equals(true)
-      expect(lc._sendRequest.getCall(0).args[0]).equals("textDocument/rename")
+      expect(lc._sendRequest.getCall(0).args[0].method).equals("textDocument/rename")
       expect(lc._sendRequest.getCall(0).args[1]).equals(params)
     })
   })
@@ -268,7 +268,7 @@ describe("LanguageClientConnection", () => {
       lc.exit()
 
       expect(lc._sendNotification.called).equals(true)
-      expect(lc._sendNotification.getCall(0).args[0]).equals("exit")
+      expect(lc._sendNotification.getCall(0).args[0].method).equals("exit")
       expect(lc._sendNotification.getCall(0).args.length).equals(1)
     })
 
@@ -276,7 +276,7 @@ describe("LanguageClientConnection", () => {
       lc.initialized()
 
       expect(lc._sendNotification.called).equals(true)
-      expect(lc._sendNotification.getCall(0).args[0]).equals("initialized")
+      expect(lc._sendNotification.getCall(0).args[0].method).equals("initialized")
       const expected: ls.InitializedParams = {}
       expect(lc._sendNotification.getCall(0).args[1]).to.deep.equal(expected)
     })
@@ -288,7 +288,7 @@ describe("LanguageClientConnection", () => {
       lc.didChangeConfiguration(params)
 
       expect(lc._sendNotification.called).equals(true)
-      expect(lc._sendNotification.getCall(0).args[0]).equals("workspace/didChangeConfiguration")
+      expect(lc._sendNotification.getCall(0).args[0].method).equals("workspace/didChangeConfiguration")
       expect(lc._sendNotification.getCall(0).args[1]).equals(params)
     })
 
@@ -299,7 +299,7 @@ describe("LanguageClientConnection", () => {
       lc.didOpenTextDocument(params)
 
       expect(lc._sendNotification.called).equals(true)
-      expect(lc._sendNotification.getCall(0).args[0]).equals("textDocument/didOpen")
+      expect(lc._sendNotification.getCall(0).args[0].method).equals("textDocument/didOpen")
       expect(lc._sendNotification.getCall(0).args[1]).equals(params)
     })
 
@@ -311,7 +311,7 @@ describe("LanguageClientConnection", () => {
       lc.didChangeTextDocument(params)
 
       expect(lc._sendNotification.called).equals(true)
-      expect(lc._sendNotification.getCall(0).args[0]).equals("textDocument/didChange")
+      expect(lc._sendNotification.getCall(0).args[0].method).equals("textDocument/didChange")
       expect(lc._sendNotification.getCall(0).args[1]).equals(params)
     })
 
@@ -322,7 +322,7 @@ describe("LanguageClientConnection", () => {
       lc.didCloseTextDocument(params)
 
       expect(lc._sendNotification.called).equals(true)
-      expect(lc._sendNotification.getCall(0).args[0]).equals("textDocument/didClose")
+      expect(lc._sendNotification.getCall(0).args[0].method).equals("textDocument/didClose")
       expect(lc._sendNotification.getCall(0).args[1]).equals(params)
     })
 
@@ -333,7 +333,7 @@ describe("LanguageClientConnection", () => {
       lc.didSaveTextDocument(params)
 
       expect(lc._sendNotification.called).equals(true)
-      expect(lc._sendNotification.getCall(0).args[0]).equals("textDocument/didSave")
+      expect(lc._sendNotification.getCall(0).args[0].method).equals("textDocument/didSave")
       expect(lc._sendNotification.getCall(0).args[1]).equals(params)
     })
 
@@ -342,7 +342,7 @@ describe("LanguageClientConnection", () => {
       lc.didChangeWatchedFiles(params)
 
       expect(lc._sendNotification.called).equals(true)
-      expect(lc._sendNotification.getCall(0).args[0]).equals("workspace/didChangeWatchedFiles")
+      expect(lc._sendNotification.getCall(0).args[0].method).equals("workspace/didChangeWatchedFiles")
       expect(lc._sendNotification.getCall(0).args[1]).equals(params)
     })
   })


### PR DESCRIPTION
Some LSP requests lack null checking and are causing errors, so I fixed them.

![image](https://user-images.githubusercontent.com/40050810/115957991-5ce60300-a540-11eb-945e-057e1b28ae36.png)

I made the following changes:
1. Added null check (https://github.com/atom-community/atom-languageclient/commit/e20bba5a4fe06b4f1a24f2063b1a60fcd5da1514)
2. Fixed the type definition (https://github.com/atom-community/atom-languageclient/commit/85cc505a5c9999e4da044996aa49e436d32d017a)
3. Use the vscode-languageserver-protocol package for type definition (https://github.com/atom-community/atom-languageclient/compare/85cc505..d665159)

If you don't need the third change, reverting it will still work.