### PR TITLE
feat: support out of the project files

### DIFF
--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -705,7 +705,7 @@ export default class AutoLanguageClient {
       point
     )
 
-    if (query !== null && this.supportsDefinitionsForAdditionalPaths && server.additionalPaths !== undefined) {
+    if (query !== null && server.additionalPaths !== undefined) {
       // populate additionalPaths based on definitions
       // Indicates that the language server can support LSP functionality for out of project files indicated by `textDocument/definition` responses.
       for (const def of query.definitions) {
@@ -999,14 +999,6 @@ export default class AutoLanguageClient {
       .filter((l) => l)
       .forEach((line) => this.logger.warn(`stderr ${line}`))
   }
-
-  /**
-   * Indicates that the language server can support LSP functionality for out of project files indicated by
-   * `textDocument/definition` responses. Set it to `true` if the server supports this feature.
-   *
-   * @default `false`
-   */
-  protected supportsDefinitionsForAdditionalPaths: boolean = false
 
   private getServerAdapter<T extends keyof ServerAdapters>(
     server: ActiveServer,

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -308,7 +308,8 @@ export default class AutoLanguageClient {
       (e) => this.shouldStartForEditor(e),
       (filepath) => this.filterChangeWatchedFiles(filepath),
       this.reportBusyWhile,
-      this.getServerName()
+      this.getServerName(),
+      this.determineProjectPath
     )
     this._serverManager.startListening()
     process.on("exit", () => this.exitCleanup.bind(this))
@@ -475,6 +476,15 @@ export default class AutoLanguageClient {
    */
   protected onSpawnExit(code: number | null, signal: NodeJS.Signals | null): void {
     this.logger.debug(`exit: code ${code} signal ${signal}`)
+  }
+
+  /** (Optional) Finds the project path. If there is a custom logic for finding projects override this method. */
+  protected determineProjectPath(textEditor: TextEditor): string | null {
+    const filePath = textEditor.getPath()
+    if (filePath == null) {
+      return null
+    }
+    return this._serverManager.getNormalizedProjectPaths().find((d) => filePath.startsWith(d)) || null
   }
 
   /**

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -47,7 +47,8 @@ export class ServerManager {
     private _startForEditor: (editor: TextEditor) => boolean,
     private _changeWatchedFileFilter: (filePath: string) => boolean,
     private _reportBusyWhile: ReportBusyWhile,
-    private _languageServerName: string
+    private _languageServerName: string,
+    private _determineProjectPath: (textEditor: TextEditor) => string | null
   ) {
     this.updateNormalizedProjectPaths()
   }
@@ -121,7 +122,7 @@ export class ServerManager {
     textEditor: TextEditor,
     { shouldStart }: { shouldStart?: boolean } = { shouldStart: false }
   ): Promise<ActiveServer | null> {
-    const finalProjectPath = this.determineProjectPath(textEditor)
+    const finalProjectPath = this._determineProjectPath(textEditor)
     if (finalProjectPath == null) {
       // Files not yet saved have no path
       return null
@@ -243,14 +244,6 @@ export class ServerManager {
       this._logger.debug(`Server terminating "${server.projectPath}"`)
       this.exitServer(server)
     })
-  }
-
-  public determineProjectPath(textEditor: TextEditor): string | null {
-    const filePath = textEditor.getPath()
-    if (filePath == null) {
-      return null
-    }
-    return this._normalizedProjectPaths.find((d) => filePath.startsWith(d)) || null
   }
 
   public updateNormalizedProjectPaths(): void {

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -22,6 +22,8 @@ export interface ActiveServer {
   process: LanguageServerProcess
   connection: ls.LanguageClientConnection
   capabilities: ls.ServerCapabilities
+  /** Out of project directories that this server can also support. */
+  additionalPaths?: Set<string>
 }
 
 interface RestartCounter {
@@ -342,4 +344,14 @@ export function normalizedProjectPathToWorkspaceFolder(normalizedProjectPath: st
 
 export function normalizePath(projectPath: string): string {
   return !projectPath.endsWith(path.sep) ? path.join(projectPath, path.sep) : projectPath
+}
+
+/** Considers a path for inclusion in `additionalPaths`. */
+export function considerAdditionalPath(
+  server: ActiveServer & { additionalPaths: Set<string> },
+  additionalPath: string
+): void {
+  if (!additionalPath.startsWith(server.projectPath)) {
+    server.additionalPaths.add(additionalPath)
+  }
 }

--- a/test/auto-languageclient.test.ts
+++ b/test/auto-languageclient.test.ts
@@ -36,6 +36,11 @@ function setupServerManager(client = setupClient()) {
 describe("AutoLanguageClient", () => {
   describe("determineProjectPath", () => {
     it("returns the project path for an internal or an external file in the project", async () => {
+      if (process.platform === "darwin") {
+        // there is nothing OS specific about the code. It just hits the limits that MacOS can handle in this test
+        pending("skipped on MacOS")
+        return
+      }
       const client = setupClient()
       const serverManager = setupServerManager(client)
 

--- a/test/auto-languageclient.test.ts
+++ b/test/auto-languageclient.test.ts
@@ -35,43 +35,31 @@ function setupServerManager(client = setupClient()) {
 
 describe("AutoLanguageClient", () => {
   describe("determineProjectPath", () => {
-    it("returns null when a single file is open", async () => {
-      const client = setupClient()
-      const textEditor = (await atom.workspace.open(__filename)) as TextEditor
-      /* eslint-disable-next-line dot-notation */
-      const projectPath = client["determineProjectPath"](textEditor)
-      expect(projectPath).toBeNull()
-    })
-    it("returns the project path when a file of that project is open", async () => {
-      // macos has issues with handling too much resources
-      if (process.platform === "darwin") {
-        return
-      }
+    it("returns the project path for an internal or an external file in the project", async () => {
       const client = setupClient()
       const serverManager = setupServerManager(client)
 
+      // "returns null when a single file is open"
+
+      let textEditor = (await atom.workspace.open(__filename)) as TextEditor
+      /* eslint-disable-next-line dot-notation */
+      expect(client["determineProjectPath"](textEditor)).toBeNull()
+      textEditor.destroy()
+
+      // "returns the project path when a file of that project is open"
       const projectPath = __dirname
 
       // gives the open workspace folder
       atom.project.addPath(projectPath)
       await serverManager.startServer(projectPath)
 
-      const textEditor = (await atom.workspace.open(__filename)) as TextEditor
+      textEditor = (await atom.workspace.open(__filename)) as TextEditor
       /* eslint-disable-next-line dot-notation */
       expect(client["determineProjectPath"](textEditor)).toBe(normalizePath(projectPath))
-    })
-    it("returns the project path for an external file if it is in additional paths", async () => {
-      // macos has issues with handling too much resources
-      if (process.platform === "darwin") {
-        return
-      }
+      textEditor.destroy()
 
       // "returns the project path when an external file is open and it is not in additional paths"
 
-      const client = setupClient()
-      const serverManager = setupServerManager(client)
-
-      const projectPath = __dirname
       const externalDir = join(dirname(projectPath), "lib")
       const externalFile = join(externalDir, "main.js")
 
@@ -79,7 +67,7 @@ describe("AutoLanguageClient", () => {
       atom.project.addPath(projectPath)
       await serverManager.startServer(projectPath)
 
-      let textEditor = (await atom.workspace.open(externalFile)) as TextEditor
+      textEditor = (await atom.workspace.open(externalFile)) as TextEditor
       /* eslint-disable-next-line dot-notation */
       expect(client["determineProjectPath"](textEditor)).toBeNull()
       textEditor.destroy()

--- a/test/auto-languageclient.test.ts
+++ b/test/auto-languageclient.test.ts
@@ -43,6 +43,10 @@ describe("AutoLanguageClient", () => {
       expect(projectPath).toBeNull()
     })
     it("returns the project path when a file of that project is open", async () => {
+      // macos has issues with handling too much resources
+      if (process.platform === "darwin") {
+        return
+      }
       const client = setupClient()
       const serverManager = setupServerManager(client)
 
@@ -57,6 +61,11 @@ describe("AutoLanguageClient", () => {
       expect(client["determineProjectPath"](textEditor)).toBe(normalizePath(projectPath))
     })
     it("returns the project path for an external file if it is in additional paths", async () => {
+      // macos has issues with handling too much resources
+      if (process.platform === "darwin") {
+        return
+      }
+
       // "returns the project path when an external file is open and it is not in additional paths"
 
       const client = setupClient()

--- a/test/auto-languageclient.test.ts
+++ b/test/auto-languageclient.test.ts
@@ -56,7 +56,9 @@ describe("AutoLanguageClient", () => {
       /* eslint-disable-next-line dot-notation */
       expect(client["determineProjectPath"](textEditor)).toBe(normalizePath(projectPath))
     })
-    it("returns the project path when an external file is open and it is not in additional paths", async () => {
+    it("returns the project path for an external file if it is in additional paths", async () => {
+      // "returns the project path when an external file is open and it is not in additional paths"
+
       const client = setupClient()
       const serverManager = setupServerManager(client)
 
@@ -68,21 +70,12 @@ describe("AutoLanguageClient", () => {
       atom.project.addPath(projectPath)
       await serverManager.startServer(projectPath)
 
-      const textEditor = (await atom.workspace.open(externalFile)) as TextEditor
+      let textEditor = (await atom.workspace.open(externalFile)) as TextEditor
       /* eslint-disable-next-line dot-notation */
       expect(client["determineProjectPath"](textEditor)).toBeNull()
-    })
-    it("returns the project path when an external file is open and it is in additional paths", async () => {
-      const client = setupClient()
-      const serverManager = setupServerManager(client)
+      textEditor.destroy()
 
-      const projectPath = __dirname
-      const externalDir = join(dirname(projectPath), "lib")
-      const externalFile = join(externalDir, "main.js")
-
-      // gives the open workspace folder
-      atom.project.addPath(projectPath)
-      await serverManager.startServer(projectPath)
+      // "returns the project path when an external file is open and it is in additional paths"
 
       // get server
       const server = serverManager.getActiveServers()[0]
@@ -91,9 +84,10 @@ describe("AutoLanguageClient", () => {
       considerAdditionalPath(server as ActiveServer & { additionalPaths: Set<string> }, externalDir)
       expect(server.additionalPaths?.has(externalDir)).toBeTrue()
 
-      const textEditor = (await atom.workspace.open(externalFile)) as TextEditor
+      textEditor = (await atom.workspace.open(externalFile)) as TextEditor
       /* eslint-disable-next-line dot-notation */
       expect(client["determineProjectPath"](textEditor)).toBe(normalizePath(projectPath))
+      textEditor.destroy()
     })
   })
   describe("ServerManager", () => {

--- a/test/auto-languageclient.test.ts
+++ b/test/auto-languageclient.test.ts
@@ -12,20 +12,26 @@ function mockEditor(uri: string, scopeName: string): any {
   }
 }
 
+function setupClient() {
+  atom.workspace.getTextEditors().forEach((editor) => editor.destroy())
+  atom.project.getPaths().forEach((project) => atom.project.removePath(project))
+  const client = new FakeAutoLanguageClient()
+  client.activate()
+  return client
+}
+
+function setupServerManager(client = setupClient()) {
+  /* eslint-disable-next-line dot-notation */
+  const serverManager = client["_serverManager"]
+  return serverManager
+}
+
 describe("AutoLanguageClient", () => {
   describe("ServerManager", () => {
     describe("WorkspaceFolders", () => {
-      let client: FakeAutoLanguageClient
       let serverManager: ServerManager
-
       beforeEach(() => {
-        atom.workspace.getTextEditors().forEach((editor) => editor.destroy())
-        atom.project.getPaths().forEach((project) => atom.project.removePath(project))
-        client = new FakeAutoLanguageClient()
-        client.activate()
-
-        /* eslint-disable-next-line dot-notation */
-        serverManager = client["_serverManager"]
+        serverManager = setupServerManager()
       })
 
       afterEach(() => {


### PR DESCRIPTION
- Moves `determineProjectPath` to `AutoLanguageClient` and passes it down to `ServerManager` in its constructor. (supercedes #11)
- Support for out-of-project files (modified from #156)
- Populate additional paths based on the definitions for such files (modified from #156)
