### PR TITLE
feat: apply additionalTextEdits after completion

### DIFF
--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -422,8 +422,6 @@ export default class AutocompleteAdapter {
       onDidConvertCompletionItem(item, suggestion as ac.AnySuggestion, request)
     }
 
-    suggestion.completionItem = item
-
     return suggestion
   }
 
@@ -440,6 +438,7 @@ export default class AutocompleteAdapter {
     suggestion.displayText = item.label
     suggestion.type = AutocompleteAdapter.completionKindToSuggestionType(item.kind)
     AutocompleteAdapter.applyDetailsToSuggestion(item, suggestion)
+    suggestion.completionItem = item
   }
 
   public static applyDetailsToSuggestion(item: CompletionItem, suggestion: Suggestion): void {

--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -17,9 +17,10 @@ import {
   ServerCapabilities,
   TextEdit,
 } from "../languageclient"
+import ApplyEditAdapter from "./apply-edit-adapter"
 import { Point, TextEditor } from "atom"
 import * as ac from "atom/autocomplete-plus"
-import { Suggestion, TextSuggestion, SnippetSuggestion } from "../types/autocomplete-extended"
+import { Suggestion, TextSuggestion, SnippetSuggestion, SuggestionBase } from "../types/autocomplete-extended"
 
 /**
  * Defines the behavior of suggestion acceptance. Assume you have "cons|ole" in the editor ( `|` is the cursor position)
@@ -494,6 +495,16 @@ export default class AutocompleteAdapter {
       suggestion.customReplacmentPrefix = editor.getTextInBufferRange([atomRange.start, originalBufferPosition])
     }
     suggestion.text = textEdit.newText
+  }
+
+  /** Handle additional text edits after a suggestion insert, e.g. `additionalTextEdits`. */
+  public static applyAdditionalTextEdits(event: ac.SuggestionInsertedEvent): void {
+    const suggestion = event.suggestion as SuggestionBase
+    const additionalEdits = suggestion.completionItem?.additionalTextEdits
+    const buffer = event.editor.getBuffer()
+
+    ApplyEditAdapter.applyEdits(buffer, Convert.convertLsTextEdits(additionalEdits))
+    buffer.groupLastChanges()
   }
 
   /**

--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -421,6 +421,8 @@ export default class AutocompleteAdapter {
       onDidConvertCompletionItem(item, suggestion as ac.AnySuggestion, request)
     }
 
+    suggestion.completionItem = item
+
     return suggestion
   }
 

--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -496,7 +496,15 @@ export default class AutocompleteAdapter {
     suggestion.text = textEdit.newText
   }
 
-  /** Handle additional text edits after a suggestion insert, e.g. `additionalTextEdits`. */
+  /**
+   * Handle additional text edits after a suggestion insert, e.g. `additionalTextEdits`.
+   *
+   * `additionalTextEdits` are An optional array of additional text edits that are applied when selecting this
+   * completion. Edits must not overlap (including the same insert position) with the main edit nor with themselves.
+   *
+   * Additional text edits should be used to change text unrelated to the current cursor position (for example adding an
+   * import statement at the top of the file if the completion item will insert an unqualified type).
+   */
   public static applyAdditionalTextEdits(event: ac.SuggestionInsertedEvent): void {
     const suggestion = event.suggestion as SuggestionBase
     const additionalEdits = suggestion.completionItem?.additionalTextEdits

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -35,7 +35,6 @@ import {
 } from "./server-manager.js"
 import { Disposable, CompositeDisposable, Point, Range, TextEditor } from "atom"
 import * as ac from "atom/autocomplete-plus"
-import { SuggestionBase } from "./types/autocomplete-extended"
 import { basename } from "path"
 
 export { ActiveServer, LanguageClientConnection, LanguageServerProcess }
@@ -640,7 +639,7 @@ export default class AutoLanguageClient {
       filterSuggestions: true,
       getSuggestions: this.getSuggestions.bind(this),
       onDidInsertSuggestion: (event) => {
-        this.handleAdditionalTextEdits(event)
+        AutocompleteAdapter.applyAdditionalTextEdits(event)
         this.onDidInsertSuggestion(event)
       },
       getSuggestionDetailsOnSelect: this.getSuggestionDetailsOnSelect.bind(this),
@@ -681,16 +680,6 @@ export default class AutoLanguageClient {
     _suggestion: ac.AnySuggestion,
     _request: ac.SuggestionsRequestedEvent
   ): void {}
-
-  /** Handle additional text edits after a suggestion insert, e.g. `additionalTextEdits`. */
-  private handleAdditionalTextEdits(event: ac.SuggestionInsertedEvent): void {
-    const suggestion = event.suggestion as SuggestionBase
-    const additionalEdits = suggestion.completionItem?.additionalTextEdits
-    const buffer = event.editor.getBuffer()
-
-    ApplyEditAdapter.applyEdits(buffer, Convert.convertLsTextEdits(additionalEdits))
-    buffer.groupLastChanges()
-  }
 
   protected onDidInsertSuggestion(_arg: ac.SuggestionInsertedEvent): void {}
 

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -35,6 +35,7 @@ import {
 } from "./server-manager.js"
 import { Disposable, CompositeDisposable, Point, Range, TextEditor } from "atom"
 import * as ac from "atom/autocomplete-plus"
+import { SuggestionBase } from "./types/autocomplete-extended"
 import { basename } from "path"
 
 export { ActiveServer, LanguageClientConnection, LanguageServerProcess }
@@ -638,7 +639,10 @@ export default class AutoLanguageClient {
       excludeLowerPriority: false,
       filterSuggestions: true,
       getSuggestions: this.getSuggestions.bind(this),
-      onDidInsertSuggestion: this.onDidInsertSuggestion.bind(this),
+      onDidInsertSuggestion: (event) => {
+        this.handleAdditionalTextEdits(event)
+        this.onDidInsertSuggestion(event)
+      },
       getSuggestionDetailsOnSelect: this.getSuggestionDetailsOnSelect.bind(this),
     }
   }
@@ -677,6 +681,16 @@ export default class AutoLanguageClient {
     _suggestion: ac.AnySuggestion,
     _request: ac.SuggestionsRequestedEvent
   ): void {}
+
+  /** Handle additional text edits after a suggestion insert, e.g. `additionalTextEdits`. */
+  private handleAdditionalTextEdits(event: ac.SuggestionInsertedEvent): void {
+    const suggestion = event.suggestion as SuggestionBase
+    const additionalEdits = suggestion.completionItem?.additionalTextEdits
+    const buffer = event.editor.getBuffer()
+
+    ApplyEditAdapter.applyEdits(buffer, Convert.convertLsTextEdits(additionalEdits))
+    buffer.groupLastChanges()
+  }
 
   protected onDidInsertSuggestion(_arg: ac.SuggestionInsertedEvent): void {}
 

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -199,7 +199,7 @@ export default class Convert {
    * @param textEdits The language server protocol {atomIde.TextEdit} objects to convert.
    * @returns An {Array} of Atom {atomIde.TextEdit} objects.
    */
-  public static convertLsTextEdits(textEdits: ls.TextEdit[] | null): atomIde.TextEdit[] {
+  public static convertLsTextEdits(textEdits?: ls.TextEdit[] | null): atomIde.TextEdit[] {
     return (textEdits || []).map(Convert.convertLsTextEdit)
   }
 

--- a/lib/types/autocomplete-extended.ts
+++ b/lib/types/autocomplete-extended.ts
@@ -2,9 +2,10 @@
 // See this PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51284
 
 import * as ac from "atom/autocomplete-plus"
+import { CompletionItem } from "../languageclient"
 
 /** Adds LSP specific properties to the Atom SuggestionBase type */
-interface SuggestionBase extends ac.SuggestionBase {
+export interface SuggestionBase extends ac.SuggestionBase {
   /**
    * A string that is used when filtering and sorting a set of completion items with a prefix present. When `falsy` the
    * [displayText](#ac.SuggestionBase.displayText) is used. When no prefix, the `sortText` property is used.
@@ -16,6 +17,9 @@ interface SuggestionBase extends ac.SuggestionBase {
    * the suggestion was gathered from.
    */
   customReplacmentPrefix?: string
+
+  /** Original completion item, if available */
+  completionItem?: CompletionItem
 }
 export type TextSuggestion = SuggestionBase & ac.TextSuggestion
 export type SnippetSuggestion = SuggestionBase & ac.SnippetSuggestion


### PR DESCRIPTION
See https://microsoft.github.io/language-server-protocol/specification#textDocument_completion

```ts
	/**
	 * An optional array of additional text edits that are applied when
	 * selecting this completion. Edits must not overlap (including the same
	 * insert position) with the main edit nor with themselves.
	 *
	 * Additional text edits should be used to change text unrelated to the
	 * current cursor position (for example adding an import statement at the
	 * top of the file if the completion item will insert an unqualified type).
	 */
```