### PR TITLE
add call hierarchy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,35 +25,36 @@ This npm package can be used by Atom package authors wanting to integrate LSP-co
 
 The language server protocol consists of a number of capabilities. Some of these already have a counterpoint we can connect up to today while others do not. The following table shows each capability in v2 and how it is exposed via Atom;
 
-| Capability                      | Atom interface              |
-| ------------------------------- | --------------------------- |
-| window/showMessage              | Notifications package       |
-| window/showMessageRequest       | Notifications package       |
-| window/logMessage               | Atom-IDE console            |
-| telemetry/event                 | Ignored                     |
-| workspace/didChangeWatchedFiles | Atom file watch API         |
-| textDocument/publishDiagnostics | Linter v2 push/indie        |
-| textDocument/completion         | AutoComplete+               |
-| completionItem/resolve          | AutoComplete+ (Atom 1.24+)  |
-| textDocument/hover              | Atom-IDE data tips          |
-| textDocument/signatureHelp      | Atom-IDE signature help     |
-| textDocument/definition         | Atom-IDE definitions        |
-| textDocument/findReferences     | Atom-IDE findReferences     |
-| textDocument/documentHighlight  | Atom-IDE code highlights    |
-| textDocument/documentSymbol     | Atom-IDE outline view       |
-| workspace/symbol                | TBD                         |
-| textDocument/codeAction         | Atom-IDE code actions       |
-| textDocument/codeLens           | TBD                         |
-| textDocument/formatting         | Format File command         |
-| textDocument/rangeFormatting    | Format Selection command    |
-| textDocument/onTypeFormatting   | Atom-IDE on type formatting |
-| textDocument/onSaveFormatting   | Atom-IDE on save formatting |
-| textDocument/rename             | TBD                         |
-| textDocument/didChange          | Send on save                |
-| textDocument/didOpen            | Send on open                |
-| textDocument/didSave            | Send after save             |
-| textDocument/willSave           | Send before save            |
-| textDocument/didClose           | Send on close               |
+| Capability                        | Atom interface              |
+| --------------------------------- | --------------------------- |
+| window/showMessage                | Notifications package       |
+| window/showMessageRequest         | Notifications package       |
+| window/logMessage                 | Atom-IDE console            |
+| telemetry/event                   | Ignored                     |
+| workspace/didChangeWatchedFiles   | Atom file watch API         |
+| textDocument/publishDiagnostics   | Linter v2 push/indie        |
+| textDocument/completion           | AutoComplete+               |
+| completionItem/resolve            | AutoComplete+ (Atom 1.24+)  |
+| textDocument/hover                | Atom-IDE data tips          |
+| textDocument/signatureHelp        | Atom-IDE signature help     |
+| textDocument/definition           | Atom-IDE definitions        |
+| textDocument/findReferences       | Atom-IDE findReferences     |
+| textDocument/documentHighlight    | Atom-IDE code highlights    |
+| textDocument/documentSymbol       | Atom-IDE outline view       |
+| workspace/symbol                  | TBD                         |
+| textDocument/codeAction           | Atom-IDE code actions       |
+| textDocument/codeLens             | TBD                         |
+| textDocument/formatting           | Format File command         |
+| textDocument/rangeFormatting      | Format Selection command    |
+| textDocument/onTypeFormatting     | Atom-IDE on type formatting |
+| textDocument/onSaveFormatting     | Atom-IDE on save formatting |
+| textDocument/prepareCallHierarchy | Atom-IDE outline view       |
+| textDocument/rename               | TBD                         |
+| textDocument/didChange            | Send on save                |
+| textDocument/didOpen              | Send on open                |
+| textDocument/didSave              | Send after save             |
+| textDocument/willSave             | Send before save            |
+| textDocument/didClose             | Send on close               |
 
 ## Developing packages
 

--- a/lib/adapters/call-hierarchy-adapter.ts
+++ b/lib/adapters/call-hierarchy-adapter.ts
@@ -8,97 +8,90 @@ import type { Point, TextEditor } from "atom"
 
 import OutlineViewAdapter from "./outline-view-adapter"
 
-/** Public: Adapts the documentSymbolProvider of the language server to the Outline View supplied by Atom IDE UI. */
-export default class CallHierarchyAdapter {
-  private _cancellationTokens = new WeakMap<LanguageClientConnection, CancellationTokenSource>()
+const cancellationTokens = new WeakMap<LanguageClientConnection, CancellationTokenSource>()
 
-  /**
-   * Public: Determine whether this adapter can be used to adapt a language server based on the serverCapabilities
-   * matrix containing a callHierarchyProvider.
-   *
-   * @param serverCapabilities The {ServerCapabilities} of the language server to consider.
-   * @returns A {Boolean} indicating adapter can adapt the server based on the given serverCapabilities.
-   */
-  public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
-    return Boolean(serverCapabilities.callHierarchyProvider)
-  }
+/**
+ * Public: Determine whether this adapter can be used to adapt a language server based on the serverCapabilities matrix
+ * containing a callHierarchyProvider.
+ *
+ * @param serverCapabilities The {ServerCapabilities} of the language server to consider.
+ * @returns A {Boolean} indicating adapter can adapt the server based on the given serverCapabilities.
+ */
+export function canAdapt(serverCapabilities: ServerCapabilities): boolean {
+  return Boolean(serverCapabilities.callHierarchyProvider)
+}
 
-  /** Corresponds to lsp's CallHierarchyPrepareRequest */
+/**
+ * Public: Obtain the relationship between calling and called functions hierarchically. Corresponds to lsp's
+ * CallHierarchyPrepareRequest.
+ *
+ * @param connection A {LanguageClientConnection} to the language server that provides highlights.
+ * @param editor The Atom {TextEditor} containing the text associated with the calling.
+ * @param position The Atom {Point} associated with the calling.
+ * @param type The hierarchy type either incoming or outgoing.
+ * @returns A {Promise} of an {CallHierarchy}.
+ */
+export async function getCallHierarchy<T extends atomIde.CallHierarchyType>(
+  connection: LanguageClientConnection,
+  editor: TextEditor,
+  point: Point,
+  type: T
+): Promise<atomIde.CallHierarchy<T>> {
+  const results = await Utils.doWithCancellationToken(connection, cancellationTokens, (cancellationToken) =>
+    connection.prepareCallHierarchy(
+      {
+        textDocument: Convert.editorToTextDocumentIdentifier(editor),
+        position: Convert.pointToPosition(point),
+      },
+      cancellationToken
+    )
+  )
+  return <CallHierarchyForAdapter<T>>{
+    type,
+    data: results?.map(convertCallHierarchyItem) ?? [],
+    itemAt(num: number) {
+      if (type === "incoming") {
+        return <Promise<atomIde.CallHierarchy<T>>>getIncoming(this.connection, this.data[num].rawData)
+      } else {
+        return <Promise<atomIde.CallHierarchy<T>>>getOutgoing(this.connection, this.data[num].rawData)
+      }
+    },
+    connection,
+  }
+}
 
-  /**
-   * Public: Obtain the relationship between calling and called functions hierarchically. Corresponds to lsp's
-   * CallHierarchyPrepareRequest.
-   *
-   * @param connection A {LanguageClientConnection} to the language server that provides highlights.
-   * @param editor The Atom {TextEditor} containing the text associated with the calling.
-   * @param position The Atom {Point} associated with the calling.
-   * @param type The hierarchy type either incoming or outgoing.
-   * @returns A {Promise} of an {CallHierarchy}.
-   */
-  async getCallHierarchy<T extends atomIde.CallHierarchyType>(
-    connection: LanguageClientConnection,
-    editor: TextEditor,
-    point: Point,
-    type: T
-  ): Promise<atomIde.CallHierarchy<T>> {
-    const results = await Utils.doWithCancellationToken(connection, this._cancellationTokens, (cancellationToken) =>
-      connection.prepareCallHierarchy(
-        {
-          textDocument: Convert.editorToTextDocumentIdentifier(editor),
-          position: Convert.pointToPosition(point),
-        },
-        cancellationToken
-      )
-    )
-    return <CallHierarchyForAdapter<T>>{
-      type,
-      data: results?.map(convertCallHierarchyItem) ?? [],
-      itemAt(num: number) {
-        if (type === "incoming") {
-          return <Promise<atomIde.CallHierarchy<T>>>this.adapter.getIncoming(this.connection, this.data[num].rawData)
-        } else {
-          return <Promise<atomIde.CallHierarchy<T>>>this.adapter.getOutgoing(this.connection, this.data[num].rawData)
-        }
-      },
-      connection,
-      adapter: this,
-    }
+/** Corresponds to lsp's CallHierarchyIncomingCallsRequest. */
+async function getIncoming(
+  connection: LanguageClientConnection,
+  item: CallHierarchyItem
+): Promise<atomIde.CallHierarchy<"incoming">> {
+  const results = await Utils.doWithCancellationToken(connection, cancellationTokens, (_cancellationToken) =>
+    connection.callHierarchyIncomingCalls({ item })
+  )
+  return <CallHierarchyForAdapter<"incoming">>{
+    type: "incoming",
+    data: results?.map((res) => convertCallHierarchyItem(res.from)) ?? [],
+    itemAt(num: number) {
+      return getIncoming(this.connection, this.data[num].rawData)
+    },
+    connection,
   }
-  /** Corresponds to lsp's CallHierarchyIncomingCallsRequest. */
-  async getIncoming(
-    connection: LanguageClientConnection,
-    item: CallHierarchyItem
-  ): Promise<atomIde.CallHierarchy<"incoming">> {
-    const results = await Utils.doWithCancellationToken(connection, this._cancellationTokens, (_cancellationToken) =>
-      connection.callHierarchyIncomingCalls({ item })
-    )
-    return <CallHierarchyForAdapter<"incoming">>{
-      type: "incoming",
-      data: results?.map((res) => convertCallHierarchyItem(res.from)) ?? [],
-      itemAt(num: number) {
-        return this.adapter.getIncoming(this.connection, this.data[num].rawData)
-      },
-      connection,
-      adapter: this,
-    }
-  }
-  /** Corresponds to lsp's CallHierarchyOutgoingCallsRequest. */
-  async getOutgoing(
-    connection: LanguageClientConnection,
-    item: CallHierarchyItem
-  ): Promise<atomIde.CallHierarchy<"outgoing">> {
-    const results = await Utils.doWithCancellationToken(connection, this._cancellationTokens, (_cancellationToken) =>
-      connection.callHierarchyOutgoingCalls({ item })
-    )
-    return <CallHierarchyForAdapter<"outgoing">>{
-      type: "outgoing",
-      data: results?.map((res) => convertCallHierarchyItem(res.to)) ?? [],
-      itemAt(num: number) {
-        return this.adapter.getOutgoing(this.connection, this.data[num].rawData)
-      },
-      connection,
-      adapter: this,
-    }
+}
+/** Corresponds to lsp's CallHierarchyOutgoingCallsRequest. */
+async function getOutgoing(
+  connection: LanguageClientConnection,
+  item: CallHierarchyItem
+): Promise<atomIde.CallHierarchy<"outgoing">> {
+  const results = await Utils.doWithCancellationToken(connection, cancellationTokens, (_cancellationToken) =>
+    connection.callHierarchyOutgoingCalls({ item })
+  )
+  return <CallHierarchyForAdapter<"outgoing">>{
+    type: "outgoing",
+    data: results?.map((res) => convertCallHierarchyItem(res.to)) ?? [],
+    itemAt(num: number) {
+      return getOutgoing(this.connection, this.data[num].rawData)
+    },
+    connection,
   }
 }
 
@@ -135,7 +128,6 @@ function symbolTagToEntityKind(symbol: number): atomIde.SymbolTagKind | null {
 /** Extend CallHierarchy to include properties used inside the adapter */
 interface CallHierarchyForAdapter<T extends atomIde.CallHierarchyType> extends atomIde.CallHierarchy<T> {
   data: CallHierarchyItemForAdapter[]
-  adapter: CallHierarchyAdapter
   connection: LanguageClientConnection
 }
 

--- a/lib/adapters/call-hierarchy-adapter.ts
+++ b/lib/adapters/call-hierarchy-adapter.ts
@@ -1,0 +1,145 @@
+import type * as atomIde from "atom-ide-base"
+import Convert from "../convert"
+import * as Utils from "../utils"
+import { SymbolTag } from "../languageclient"
+import type { LanguageClientConnection, ServerCapabilities, CallHierarchyItem } from "../languageclient"
+import type { CancellationTokenSource } from "vscode-jsonrpc"
+import type { Point, TextEditor } from "atom"
+
+import OutlineViewAdapter from "./outline-view-adapter"
+
+/** Public: Adapts the documentSymbolProvider of the language server to the Outline View supplied by Atom IDE UI. */
+export default class CallHierarchyAdapter {
+  private _cancellationTokens: WeakMap<LanguageClientConnection, CancellationTokenSource> = new WeakMap()
+
+  /**
+   * Public: Determine whether this adapter can be used to adapt a language server based on the serverCapabilities
+   * matrix containing a callHierarchyProvider.
+   *
+   * @param serverCapabilities The {ServerCapabilities} of the language server to consider.
+   * @returns A {Boolean} indicating adapter can adapt the server based on the given serverCapabilities.
+   */
+  public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
+    return !!serverCapabilities.callHierarchyProvider
+  }
+
+  /** Corresponds to lsp's CallHierarchyPrepareRequest */
+
+  /**
+   * Public: Obtain the relationship between calling and called functions hierarchically. Corresponds to lsp's
+   * CallHierarchyPrepareRequest.
+   *
+   * @param connection A {LanguageClientConnection} to the language server that provides highlights.
+   * @param editor The Atom {TextEditor} containing the text associated with the calling.
+   * @param position The Atom {Point} associated with the calling.
+   * @param type The hierarchy type either incoming or outgoing.
+   * @returns A {Promise} of an {CallHierarchy}.
+   */
+  async getCallHierarchy<T extends atomIde.CallHierarchyType>(
+    connection: LanguageClientConnection,
+    editor: TextEditor,
+    point: Point,
+    type: T
+  ): Promise<atomIde.CallHierarchy<T>> {
+    const results = await Utils.doWithCancellationToken(connection, this._cancellationTokens, (cancellationToken) =>
+      connection.prepareCallHierarchy(
+        {
+          textDocument: Convert.editorToTextDocumentIdentifier(editor),
+          position: Convert.pointToPosition(point),
+        },
+        cancellationToken
+      )
+    )
+    return <CallHierarchyForAdapter<T>>{
+      type,
+      data: results?.map(convertCallHierarchyItem) ?? [],
+      itemAt(n: number) {
+        if (type === "incoming") {
+          return <Promise<atomIde.CallHierarchy<T>>>this.adapter.getIncoming(this.connection, this.data[n].rawData)
+        } else {
+          return <Promise<atomIde.CallHierarchy<T>>>this.adapter.getOutgoing(this.connection, this.data[n].rawData)
+        }
+      },
+      connection,
+      adapter: this,
+    }
+  }
+  /** Corresponds to lsp's CallHierarchyIncomingCallsRequest. */
+  async getIncoming(
+    connection: LanguageClientConnection,
+    item: CallHierarchyItem
+  ): Promise<atomIde.CallHierarchy<"incoming">> {
+    const results = await Utils.doWithCancellationToken(connection, this._cancellationTokens, (_cancellationToken) =>
+      connection.callHierarchyIncomingCalls({ item })
+    )
+    return <CallHierarchyForAdapter<"incoming">>{
+      type: "incoming",
+      data: results?.map?.((l) => convertCallHierarchyItem(l.from)) || [],
+      itemAt(n: number) {
+        return this.adapter.getIncoming(this.connection, this.data[n].rawData)
+      },
+      connection,
+      adapter: this,
+    }
+  }
+  /** Corresponds to lsp's CallHierarchyOutgoingCallsRequest. */
+  async getOutgoing(
+    connection: LanguageClientConnection,
+    item: CallHierarchyItem
+  ): Promise<atomIde.CallHierarchy<"outgoing">> {
+    const results = await Utils.doWithCancellationToken(connection, this._cancellationTokens, (_cancellationToken) =>
+      connection.callHierarchyOutgoingCalls({ item })
+    )
+    return <CallHierarchyForAdapter<"outgoing">>{
+      type: "outgoing",
+      data: results?.map((l) => convertCallHierarchyItem(l.to)) || [],
+      itemAt(n: number) {
+        return this.adapter.getOutgoing(this.connection, this.data[n].rawData)
+      },
+      connection,
+      adapter: this,
+    }
+  }
+}
+
+function convertCallHierarchyItem(rawData: CallHierarchyItem): CallHierarchyItemForAdapter {
+  return {
+    path: Convert.uriToPath(rawData.uri),
+    name: rawData.name,
+    icon: OutlineViewAdapter.symbolKindToEntityKind(rawData.kind) ?? undefined,
+    tags: rawData.tags
+      ? [
+          ...rawData.tags.reduce((set, tag) => {
+            // filter out null and remove duplicates
+            const entity = symbolTagToEntityKind(tag)
+            return entity == null ? set : set.add(entity)
+          }, new Set<atomIde.SymbolTagKind>()),
+        ]
+      : [],
+    detail: rawData.detail,
+    range: Convert.lsRangeToAtomRange(rawData.range),
+    selectionRange: Convert.lsRangeToAtomRange(rawData.selectionRange),
+    rawData,
+  }
+}
+
+function symbolTagToEntityKind(symbol: number): atomIde.SymbolTagKind | null {
+  switch (symbol) {
+    case SymbolTag.Deprecated:
+      return "deprecated"
+    default:
+      return null
+  }
+}
+
+/** Extend CallHierarchy to include properties used inside the adapter */
+interface CallHierarchyForAdapter<T extends atomIde.CallHierarchyType> extends atomIde.CallHierarchy<T> {
+  data: CallHierarchyItemForAdapter[]
+  adapter: CallHierarchyAdapter
+  connection: LanguageClientConnection
+}
+
+/** Extend CallHierarchyItem to include properties used inside the adapter */
+interface CallHierarchyItemForAdapter extends atomIde.CallHierarchyItem {
+  rawData: CallHierarchyItem
+}

--- a/lib/adapters/call-hierarchy-adapter.ts
+++ b/lib/adapters/call-hierarchy-adapter.ts
@@ -10,7 +10,7 @@ import OutlineViewAdapter from "./outline-view-adapter"
 
 /** Public: Adapts the documentSymbolProvider of the language server to the Outline View supplied by Atom IDE UI. */
 export default class CallHierarchyAdapter {
-  private _cancellationTokens: WeakMap<LanguageClientConnection, CancellationTokenSource> = new WeakMap()
+  private _cancellationTokens = new WeakMap<LanguageClientConnection, CancellationTokenSource>()
 
   /**
    * Public: Determine whether this adapter can be used to adapt a language server based on the serverCapabilities
@@ -20,7 +20,7 @@ export default class CallHierarchyAdapter {
    * @returns A {Boolean} indicating adapter can adapt the server based on the given serverCapabilities.
    */
   public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
-    return !!serverCapabilities.callHierarchyProvider
+    return Boolean(serverCapabilities.callHierarchyProvider)
   }
 
   /** Corresponds to lsp's CallHierarchyPrepareRequest */
@@ -53,11 +53,11 @@ export default class CallHierarchyAdapter {
     return <CallHierarchyForAdapter<T>>{
       type,
       data: results?.map(convertCallHierarchyItem) ?? [],
-      itemAt(n: number) {
+      itemAt(num: number) {
         if (type === "incoming") {
-          return <Promise<atomIde.CallHierarchy<T>>>this.adapter.getIncoming(this.connection, this.data[n].rawData)
+          return <Promise<atomIde.CallHierarchy<T>>>this.adapter.getIncoming(this.connection, this.data[num].rawData)
         } else {
-          return <Promise<atomIde.CallHierarchy<T>>>this.adapter.getOutgoing(this.connection, this.data[n].rawData)
+          return <Promise<atomIde.CallHierarchy<T>>>this.adapter.getOutgoing(this.connection, this.data[num].rawData)
         }
       },
       connection,
@@ -74,9 +74,9 @@ export default class CallHierarchyAdapter {
     )
     return <CallHierarchyForAdapter<"incoming">>{
       type: "incoming",
-      data: results?.map?.((l) => convertCallHierarchyItem(l.from)) || [],
-      itemAt(n: number) {
-        return this.adapter.getIncoming(this.connection, this.data[n].rawData)
+      data: results?.map((res) => convertCallHierarchyItem(res.from)) ?? [],
+      itemAt(num: number) {
+        return this.adapter.getIncoming(this.connection, this.data[num].rawData)
       },
       connection,
       adapter: this,
@@ -92,9 +92,9 @@ export default class CallHierarchyAdapter {
     )
     return <CallHierarchyForAdapter<"outgoing">>{
       type: "outgoing",
-      data: results?.map((l) => convertCallHierarchyItem(l.to)) || [],
-      itemAt(n: number) {
-        return this.adapter.getOutgoing(this.connection, this.data[n].rawData)
+      data: results?.map((res) => convertCallHierarchyItem(res.to)) ?? [],
+      itemAt(num: number) {
+        return this.adapter.getOutgoing(this.connection, this.data[num].rawData)
       },
       connection,
       adapter: this,
@@ -112,7 +112,7 @@ function convertCallHierarchyItem(rawData: CallHierarchyItem): CallHierarchyItem
           ...rawData.tags.reduce((set, tag) => {
             // filter out null and remove duplicates
             const entity = symbolTagToEntityKind(tag)
-            return entity == null ? set : set.add(entity)
+            return entity === null ? set : set.add(entity)
           }, new Set<atomIde.SymbolTagKind>()),
         ]
       : [],

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -765,10 +765,10 @@ export default class AutoLanguageClient {
     point: Point
   ): Promise<atomIde.CallHierarchy<"incoming"> | null> {
     const server = await this._serverManager.getServer(editor)
-    if (server == null || !CallHierarchyAdapter.canAdapt(server.capabilities)) {
+    if (server === null || !CallHierarchyAdapter.canAdapt(server.capabilities)) {
       return null
     }
-    this.callHierarchy = this.callHierarchy || new CallHierarchyAdapter()
+    this.callHierarchy = this.callHierarchy ?? new CallHierarchyAdapter()
     return this.callHierarchy.getCallHierarchy(server.connection, editor, point, "incoming")
   }
 
@@ -777,10 +777,10 @@ export default class AutoLanguageClient {
     point: Point
   ): Promise<atomIde.CallHierarchy<"outgoing"> | null> {
     const server = await this._serverManager.getServer(editor)
-    if (server == null || !CallHierarchyAdapter.canAdapt(server.capabilities)) {
+    if (server === null || !CallHierarchyAdapter.canAdapt(server.capabilities)) {
       return null
     }
-    this.callHierarchy = this.callHierarchy || new CallHierarchyAdapter()
+    this.callHierarchy = this.callHierarchy ?? new CallHierarchyAdapter()
     return this.callHierarchy.getCallHierarchy(server.connection, editor, point, "outgoing")
   }
 

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -8,7 +8,7 @@ import * as linter from "atom/linter"
 import Convert from "./convert.js"
 import ApplyEditAdapter from "./adapters/apply-edit-adapter"
 import AutocompleteAdapter, { grammarScopeToAutoCompleteSelector } from "./adapters/autocomplete-adapter"
-import CallHierarchyAdapter from "./adapters/call-hierarchy-adapter"
+import * as CallHierarchyAdapter from "./adapters/call-hierarchy-adapter"
 import CodeActionAdapter from "./adapters/code-action-adapter"
 import CodeFormatAdapter from "./adapters/code-format-adapter"
 import CodeHighlightAdapter from "./adapters/code-highlight-adapter"
@@ -76,7 +76,7 @@ export default class AutoLanguageClient {
 
   // Shared adapters that can take the RPC connection as required
   protected autoComplete?: AutocompleteAdapter
-  protected callHierarchy?: CallHierarchyAdapter
+  protected callHierarchy?: typeof CallHierarchyAdapter
   protected datatip?: DatatipAdapter
   protected definitions?: DefinitionAdapter
   protected findReferences?: FindReferencesAdapter
@@ -768,7 +768,7 @@ export default class AutoLanguageClient {
     if (server === null || !CallHierarchyAdapter.canAdapt(server.capabilities)) {
       return null
     }
-    this.callHierarchy = this.callHierarchy ?? new CallHierarchyAdapter()
+    this.callHierarchy = this.callHierarchy ?? CallHierarchyAdapter
     return this.callHierarchy.getCallHierarchy(server.connection, editor, point, "incoming")
   }
 
@@ -780,7 +780,7 @@ export default class AutoLanguageClient {
     if (server === null || !CallHierarchyAdapter.canAdapt(server.capabilities)) {
       return null
     }
-    this.callHierarchy = this.callHierarchy ?? new CallHierarchyAdapter()
+    this.callHierarchy = this.callHierarchy ?? CallHierarchyAdapter
     return this.callHierarchy.getCallHierarchy(server.connection, editor, point, "outgoing")
   }
 

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -8,6 +8,7 @@ import * as linter from "atom/linter"
 import Convert from "./convert.js"
 import ApplyEditAdapter from "./adapters/apply-edit-adapter"
 import AutocompleteAdapter, { grammarScopeToAutoCompleteSelector } from "./adapters/autocomplete-adapter"
+import CallHierarchyAdapter from "./adapters/call-hierarchy-adapter"
 import CodeActionAdapter from "./adapters/code-action-adapter"
 import CodeFormatAdapter from "./adapters/code-format-adapter"
 import CodeHighlightAdapter from "./adapters/code-highlight-adapter"
@@ -75,6 +76,7 @@ export default class AutoLanguageClient {
 
   // Shared adapters that can take the RPC connection as required
   protected autoComplete?: AutocompleteAdapter
+  protected callHierarchy?: CallHierarchyAdapter
   protected datatip?: DatatipAdapter
   protected definitions?: DefinitionAdapter
   protected findReferences?: FindReferencesAdapter
@@ -247,13 +249,15 @@ export default class AutoLanguageClient {
             codeDescriptionSupport: true,
             dataSupport: true,
           },
+          callHierarchy: {
+            dynamicRegistration: false,
+          },
           implementation: undefined,
           typeDefinition: undefined,
           colorProvider: undefined,
           foldingRange: undefined,
           selectionRange: undefined,
           linkedEditingRange: undefined,
-          callHierarchy: undefined,
           semanticTokens: undefined,
         },
         general: {
@@ -743,6 +747,41 @@ export default class AutoLanguageClient {
 
     this.outlineView = this.outlineView || new OutlineViewAdapter()
     return this.outlineView.getOutline(server.connection, editor)
+  }
+
+  // Call Hierarchy View via LS callHierarchy---------------------------------
+  public provideCallHierarchy(): atomIde.CallHierarchyProvider {
+    return {
+      name: this.name,
+      grammarScopes: this.getGrammarScopes(),
+      priority: 1,
+      getIncomingCallHierarchy: this.getIncomingCallHierarchy.bind(this),
+      getOutgoingCallHierarchy: this.getOutgoingCallHierarchy.bind(this),
+    }
+  }
+
+  protected async getIncomingCallHierarchy(
+    editor: TextEditor,
+    point: Point
+  ): Promise<atomIde.CallHierarchy<"incoming"> | null> {
+    const server = await this._serverManager.getServer(editor)
+    if (server == null || !CallHierarchyAdapter.canAdapt(server.capabilities)) {
+      return null
+    }
+    this.callHierarchy = this.callHierarchy || new CallHierarchyAdapter()
+    return this.callHierarchy.getCallHierarchy(server.connection, editor, point, "incoming")
+  }
+
+  protected async getOutgoingCallHierarchy(
+    editor: TextEditor,
+    point: Point
+  ): Promise<atomIde.CallHierarchy<"outgoing"> | null> {
+    const server = await this._serverManager.getServer(editor)
+    if (server == null || !CallHierarchyAdapter.canAdapt(server.capabilities)) {
+      return null
+    }
+    this.callHierarchy = this.callHierarchy || new CallHierarchyAdapter()
+    return this.callHierarchy.getCallHierarchy(server.connection, editor, point, "outgoing")
   }
 
   // Linter push v2 API via LS publishDiagnostics

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -533,6 +533,51 @@ export class LanguageClientConnection extends EventEmitter {
     return this._sendRequest(lsp.ExecuteCommandRequest.type, params)
   }
 
+  /**
+   * Public: Send a `textDocument/prepareCallHierarchy` request.
+   *
+   * @param params The {CallHierarchyIncomingCallsParams} that containing {textDocument} and {position} associated with
+   *   the calling.
+   * @param cancellationToken The {CancellationToken} that is used to cancel this request if necessary.
+   * @returns A {Promise} containing an {Array} of {CallHierarchyItem}s that corresponding to the request.
+   */
+  public prepareCallHierarchy(
+    params: lsp.CallHierarchyPrepareParams,
+    _cancellationToken?: jsonrpc.CancellationToken
+  ): Promise<lsp.CallHierarchyItem[] | null> {
+    return this._sendRequest(lsp.CallHierarchyPrepareRequest.type, params)
+  }
+
+  /**
+   * Public: Send a `callHierarchy/incomingCalls` request.
+   *
+   * @param params The {CallHierarchyIncomingCallsParams} that identifies {CallHierarchyItem} to get incoming calls.
+   * @param cancellationToken The {CancellationToken} that is used to cancel this request if necessary.
+   * @returns A {Promise} containing an {Array} of {CallHierarchyIncomingCall}s for the function that called by the
+   *   function given to the parameter.
+   */
+  public callHierarchyIncomingCalls(
+    params: lsp.CallHierarchyIncomingCallsParams,
+    _cancellationToken?: jsonrpc.CancellationToken
+  ): Promise<lsp.CallHierarchyIncomingCall[] | null> {
+    return this._sendRequest(lsp.CallHierarchyIncomingCallsRequest.type, params)
+  }
+
+  /**
+   * Public: Send a `callHierarchy/outgoingCalls` request.
+   *
+   * @param params The {CallHierarchyOutgoingCallsParams} that identifies {CallHierarchyItem} to get outgoing calls.
+   * @param cancellationToken The {CancellationToken} that is used to cancel this request if necessary.
+   * @returns A {Promise} containing an {Array} of {CallHierarchyIncomingCall}s for the function that calls the function
+   *   given to the parameter.
+   */
+  public callHierarchyOutgoingCalls(
+    params: lsp.CallHierarchyOutgoingCallsParams,
+    _cancellationToken?: jsonrpc.CancellationToken
+  ): Promise<lsp.CallHierarchyOutgoingCall[] | null> {
+    return this._sendRequest(lsp.CallHierarchyOutgoingCallsRequest.type, params)
+  }
+
   private _onRequest<T extends Extract<keyof KnownRequests, string>>(
     type: { method: T },
     callback: RequestCallback<T>

--- a/test/adapters/call-hierarchy-adapter.test.ts
+++ b/test/adapters/call-hierarchy-adapter.test.ts
@@ -1,4 +1,4 @@
-import CallHierarchyAdapter from "../../lib/adapters/call-hierarchy-adapter"
+import * as CallHierarchyAdapter from "../../lib/adapters/call-hierarchy-adapter"
 import * as ls from "../../lib/languageclient"
 import { createSpyConnection, createFakeEditor } from "../helpers.js"
 import { Point, Range } from "atom"
@@ -64,7 +64,7 @@ describe("CallHierarchyAdapter", () => {
     it("converts the results from the connection", async () => {
       spyOn(connection, "prepareCallHierarchy").and.resolveTo([callHierarchyItem])
       const result = <any>(
-        await new CallHierarchyAdapter().getCallHierarchy(connection, fakeEditor, new Point(0, 0), "incoming")
+        await CallHierarchyAdapter.getCallHierarchy(connection, fakeEditor, new Point(0, 0), "incoming")
       )
       expect(result.type).toEqual("incoming")
       expect(result.data).toEqual([
@@ -83,7 +83,7 @@ describe("CallHierarchyAdapter", () => {
     it("converts the results with tags from the connection", async () => {
       spyOn(connection, "prepareCallHierarchy").and.resolveTo([callHierarchyItemWithTags])
       const result = <any>(
-        await new CallHierarchyAdapter().getCallHierarchy(connection, fakeEditor, new Point(0, 0), "incoming")
+        await CallHierarchyAdapter.getCallHierarchy(connection, fakeEditor, new Point(0, 0), "incoming")
       )
       expect(result.type).toEqual("incoming")
       expect(result.data).toEqual([
@@ -102,7 +102,7 @@ describe("CallHierarchyAdapter", () => {
     it("converts null results from the connection", async () => {
       spyOn(connection, "prepareCallHierarchy").and.resolveTo(null)
       const result = <any>(
-        await new CallHierarchyAdapter().getCallHierarchy(connection, fakeEditor, new Point(0, 0), "outgoing")
+        await CallHierarchyAdapter.getCallHierarchy(connection, fakeEditor, new Point(0, 0), "outgoing")
       )
       expect(result.type).toEqual("outgoing")
       expect(result.data).toEqual([])
@@ -110,7 +110,7 @@ describe("CallHierarchyAdapter", () => {
     it("converts empty results from the connection", async () => {
       spyOn(connection, "prepareCallHierarchy").and.resolveTo([])
       const result = <any>(
-        await new CallHierarchyAdapter().getCallHierarchy(connection, fakeEditor, new Point(0, 0), "outgoing")
+        await CallHierarchyAdapter.getCallHierarchy(connection, fakeEditor, new Point(0, 0), "outgoing")
       )
       expect(result.type).toEqual("outgoing")
       expect(result.data).toEqual([])
@@ -124,7 +124,7 @@ describe("CallHierarchyAdapter", () => {
         },
       ])
       const result = <any>(
-        await new CallHierarchyAdapter().getCallHierarchy(connection, fakeEditor, new Point(0, 0), "incoming")
+        await CallHierarchyAdapter.getCallHierarchy(connection, fakeEditor, new Point(0, 0), "incoming")
       )
       expect((await result.itemAt(0)).type).toEqual("incoming")
       expect((await result.itemAt(0)).data).toEqual([
@@ -162,7 +162,7 @@ describe("CallHierarchyAdapter", () => {
         },
       ])
       const result = <any>(
-        await new CallHierarchyAdapter().getCallHierarchy(connection, fakeEditor, new Point(0, 0), "outgoing")
+        await CallHierarchyAdapter.getCallHierarchy(connection, fakeEditor, new Point(0, 0), "outgoing")
       )
       expect((await result.itemAt(0)).type).toEqual("outgoing")
       expect((await result.itemAt(0)).data).toEqual([
@@ -195,7 +195,7 @@ describe("CallHierarchyAdapter", () => {
       setProcessPlatform("darwin")
       spyOn(connection, "prepareCallHierarchy").and.resolveTo([callHierarchyItem])
       const result = <any>(
-        await new CallHierarchyAdapter().getCallHierarchy(connection, fakeEditor, new Point(0, 0), "outgoing")
+        await CallHierarchyAdapter.getCallHierarchy(connection, fakeEditor, new Point(0, 0), "outgoing")
       )
       expect(result.data[0].path).toEqual("/path/to/file.ts")
     })
@@ -203,7 +203,7 @@ describe("CallHierarchyAdapter", () => {
       setProcessPlatform("win32")
       spyOn(connection, "prepareCallHierarchy").and.resolveTo([callHierarchyItemInWin32])
       const result = <any>(
-        await new CallHierarchyAdapter().getCallHierarchy(connection, fakeEditor, new Point(0, 0), "outgoing")
+        await CallHierarchyAdapter.getCallHierarchy(connection, fakeEditor, new Point(0, 0), "outgoing")
       )
       expect(result.data[0].path).toEqual("C:\\path\\to\\file.ts")
     })
@@ -211,13 +211,18 @@ describe("CallHierarchyAdapter", () => {
 
   describe("getIncoming", () => {
     it("converts the results from the connection", async () => {
+      spyOn(connection, "prepareCallHierarchy").and.resolveTo([callHierarchyItem])
       spyOn(connection, "callHierarchyIncomingCalls").and.resolveTo([
         {
           from: callHierarchyItem,
           fromRanges: [],
         },
       ])
-      const result = <any>await new CallHierarchyAdapter().getIncoming(connection, callHierarchyItem)
+      const result = <any>(
+        await (
+          await CallHierarchyAdapter.getCallHierarchy(connection, fakeEditor, new Point(0, 0), "incoming")
+        ).itemAt(0)
+      )
       expect(result.type).toEqual("incoming")
       expect(result.data).toEqual([
         {
@@ -233,50 +238,75 @@ describe("CallHierarchyAdapter", () => {
       ])
     })
     it("converts null results from the connection", async () => {
+      spyOn(connection, "prepareCallHierarchy").and.resolveTo([callHierarchyItem])
       spyOn(connection, "callHierarchyIncomingCalls").and.resolveTo(null)
-      const result = <any>await new CallHierarchyAdapter().getIncoming(connection, callHierarchyItem)
+      const result = <any>(
+        await (
+          await CallHierarchyAdapter.getCallHierarchy(connection, fakeEditor, new Point(0, 0), "incoming")
+        ).itemAt(0)
+      )
       expect(result.type).toEqual("incoming")
       expect(result.data).toEqual([])
     })
     it("converts empty results from the connection", async () => {
+      spyOn(connection, "prepareCallHierarchy").and.resolveTo([callHierarchyItem])
       spyOn(connection, "callHierarchyIncomingCalls").and.resolveTo([])
-      const result = <any>await new CallHierarchyAdapter().getIncoming(connection, callHierarchyItem)
+      const result = <any>(
+        await (
+          await CallHierarchyAdapter.getCallHierarchy(connection, fakeEditor, new Point(0, 0), "incoming")
+        ).itemAt(0)
+      )
       expect(result.type).toEqual("incoming")
       expect(result.data).toEqual([])
     })
     it("convert paths in darwin", async () => {
       setProcessPlatform("darwin")
+      spyOn(connection, "prepareCallHierarchy").and.resolveTo([callHierarchyItem])
       spyOn(connection, "callHierarchyIncomingCalls").and.resolveTo([
         {
           from: callHierarchyItem,
           fromRanges: [],
         },
       ])
-      const result = <any>await new CallHierarchyAdapter().getIncoming(connection, callHierarchyItem)
+      const result = <any>(
+        await (
+          await CallHierarchyAdapter.getCallHierarchy(connection, fakeEditor, new Point(0, 0), "incoming")
+        ).itemAt(0)
+      )
       expect(result.data[0].path).toEqual("/path/to/file.ts")
     })
     it("convert paths in win32", async () => {
       setProcessPlatform("win32")
+      spyOn(connection, "prepareCallHierarchy").and.resolveTo([callHierarchyItem])
       spyOn(connection, "callHierarchyIncomingCalls").and.resolveTo([
         {
           from: callHierarchyItemInWin32,
           fromRanges: [],
         },
       ])
-      const result = <any>await new CallHierarchyAdapter().getIncoming(connection, callHierarchyItem)
+      const result = <any>(
+        await (
+          await CallHierarchyAdapter.getCallHierarchy(connection, fakeEditor, new Point(0, 0), "incoming")
+        ).itemAt(0)
+      )
       expect(result.data[0].path).toEqual("C:\\path\\to\\file.ts")
     })
   })
 
   describe("getOutgoing", () => {
     it("converts the results from the connection", async () => {
+      spyOn(connection, "prepareCallHierarchy").and.resolveTo([callHierarchyItem])
       spyOn(connection, "callHierarchyOutgoingCalls").and.resolveTo([
         {
           to: callHierarchyItem,
           fromRanges: [],
         },
       ])
-      const result = <any>await new CallHierarchyAdapter().getOutgoing(connection, callHierarchyItem)
+      const result = <any>(
+        await (
+          await CallHierarchyAdapter.getCallHierarchy(connection, fakeEditor, new Point(0, 0), "outgoing")
+        ).itemAt(0)
+      )
       expect(result.type).toEqual("outgoing")
       expect(result.data).toEqual([
         {
@@ -292,37 +322,57 @@ describe("CallHierarchyAdapter", () => {
       ])
     })
     it("converts null results from the connection", async () => {
+      spyOn(connection, "prepareCallHierarchy").and.resolveTo([callHierarchyItem])
       spyOn(connection, "callHierarchyOutgoingCalls").and.resolveTo(null)
-      const result = <any>await new CallHierarchyAdapter().getOutgoing(connection, callHierarchyItem)
+      const result = <any>(
+        await (
+          await CallHierarchyAdapter.getCallHierarchy(connection, fakeEditor, new Point(0, 0), "outgoing")
+        ).itemAt(0)
+      )
       expect(result.type).toEqual("outgoing")
       expect(result.data).toEqual([])
     })
     it("converts empty results from the connection", async () => {
+      spyOn(connection, "prepareCallHierarchy").and.resolveTo([callHierarchyItem])
       spyOn(connection, "callHierarchyOutgoingCalls").and.resolveTo([])
-      const result = <any>await new CallHierarchyAdapter().getOutgoing(connection, callHierarchyItem)
+      const result = <any>(
+        await (
+          await CallHierarchyAdapter.getCallHierarchy(connection, fakeEditor, new Point(0, 0), "outgoing")
+        ).itemAt(0)
+      )
       expect(result.type).toEqual("outgoing")
       expect(result.data).toEqual([])
     })
     it("convert paths in darwin", async () => {
       setProcessPlatform("darwin")
+      spyOn(connection, "prepareCallHierarchy").and.resolveTo([callHierarchyItem])
       spyOn(connection, "callHierarchyOutgoingCalls").and.resolveTo([
         {
           to: callHierarchyItem,
           fromRanges: [],
         },
       ])
-      const result = <any>await new CallHierarchyAdapter().getOutgoing(connection, callHierarchyItem)
+      const result = <any>(
+        await (
+          await CallHierarchyAdapter.getCallHierarchy(connection, fakeEditor, new Point(0, 0), "outgoing")
+        ).itemAt(0)
+      )
       expect(result.data[0].path).toEqual("/path/to/file.ts")
     })
     it("convert paths in win32", async () => {
       setProcessPlatform("win32")
+      spyOn(connection, "prepareCallHierarchy").and.resolveTo([callHierarchyItem])
       spyOn(connection, "callHierarchyOutgoingCalls").and.resolveTo([
         {
           to: callHierarchyItemInWin32,
           fromRanges: [],
         },
       ])
-      const result = <any>await new CallHierarchyAdapter().getOutgoing(connection, callHierarchyItem)
+      const result = <any>(
+        await (
+          await CallHierarchyAdapter.getCallHierarchy(connection, fakeEditor, new Point(0, 0), "outgoing")
+        ).itemAt(0)
+      )
       expect(result.data[0].path).toEqual("C:\\path\\to\\file.ts")
     })
   })

--- a/test/adapters/call-hierarchy-adapter.test.ts
+++ b/test/adapters/call-hierarchy-adapter.test.ts
@@ -4,6 +4,7 @@ import { createSpyConnection, createFakeEditor } from "../helpers.js"
 import { Point, Range } from "atom"
 import type { TextEditor } from "atom"
 
+let originalPlatform: NodeJS.Platform
 const setProcessPlatform = (platform: any) => {
   Object.defineProperty(process, "platform", { value: platform })
 }
@@ -34,13 +35,17 @@ const callHierarchyItemInWin32: ls.CallHierarchyItem = {
   selectionRange: { start: { line: 0, character: 24 }, end: { line: 0, character: 29 } },
 }
 
-describe("OutlineViewAdapter", () => {
+describe("CallHierarchyAdapter", () => {
   let fakeEditor: TextEditor
   let connection: ls.LanguageClientConnection
 
   beforeEach(() => {
     connection = new ls.LanguageClientConnection(createSpyConnection())
     fakeEditor = createFakeEditor()
+    originalPlatform = process.platform
+  })
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform })
   })
 
   describe("canAdapt", () => {

--- a/test/adapters/call-hierarchy-adapter.test.ts
+++ b/test/adapters/call-hierarchy-adapter.test.ts
@@ -1,0 +1,252 @@
+import CallHierarchyAdapter from "../../lib/adapters/call-hierarchy-adapter"
+import * as ls from "../../lib/languageclient"
+import { createSpyConnection, createFakeEditor } from "../helpers.js"
+import { Point, Range } from "atom"
+import type { TextEditor } from "atom"
+
+const callHierarchyItem: ls.CallHierarchyItem = {
+  name: "hello",
+  kind: 12,
+  detail: "",
+  uri: "file:///C:/path/to/file.ts",
+  range: { start: { line: 0, character: 0 }, end: { line: 1, character: 1 } },
+  selectionRange: { start: { line: 0, character: 24 }, end: { line: 0, character: 29 } },
+}
+const callHierarchyItemWithTags: ls.CallHierarchyItem = {
+  name: "hello",
+  kind: 12,
+  tags: [1],
+  detail: "",
+  uri: "file:///C:/path/to/file.ts",
+  range: { start: { line: 0, character: 0 }, end: { line: 1, character: 1 } },
+  selectionRange: { start: { line: 0, character: 24 }, end: { line: 0, character: 29 } },
+}
+
+describe("OutlineViewAdapter", () => {
+  let fakeEditor: TextEditor
+  let connection: ls.LanguageClientConnection
+
+  beforeEach(() => {
+    connection = new ls.LanguageClientConnection(createSpyConnection())
+    fakeEditor = createFakeEditor()
+  })
+
+  describe("canAdapt", () => {
+    it("returns true if callHierarchyProvider is supported", () => {
+      const result = CallHierarchyAdapter.canAdapt({ callHierarchyProvider: true })
+      expect(result).toBe(true)
+    })
+
+    it("returns false if callHierarchyProvider not supported", () => {
+      const result = CallHierarchyAdapter.canAdapt({})
+      expect(result).toBe(false)
+    })
+  })
+
+  describe("getCallHierarchy", () => {
+    it("converts the results from the connection", async () => {
+      spyOn(connection, "prepareCallHierarchy").and.resolveTo([callHierarchyItem])
+      const result = <any>(
+        await new CallHierarchyAdapter().getCallHierarchy(connection, fakeEditor, new Point(0, 0), "incoming")
+      )
+      expect(result.type).toEqual("incoming")
+      expect(result.data).toEqual([
+        {
+          path: "C:\\path\\to\\file.ts",
+          name: "hello",
+          icon: "type-function",
+          tags: [],
+          detail: "",
+          range: new Range([0, 0], [1, 1]),
+          selectionRange: new Range([0, 24], [0, 29]),
+          rawData: jasmine.anything(),
+        },
+      ])
+    })
+    it("converts the results with tags from the connection", async () => {
+      spyOn(connection, "prepareCallHierarchy").and.resolveTo([callHierarchyItemWithTags])
+      const result = <any>(
+        await new CallHierarchyAdapter().getCallHierarchy(connection, fakeEditor, new Point(0, 0), "incoming")
+      )
+      expect(result.type).toEqual("incoming")
+      expect(result.data).toEqual([
+        {
+          path: "C:\\path\\to\\file.ts",
+          name: "hello",
+          icon: "type-function",
+          tags: ["deprecated"],
+          detail: "",
+          range: new Range([0, 0], [1, 1]),
+          selectionRange: new Range([0, 24], [0, 29]),
+          rawData: jasmine.anything(),
+        },
+      ])
+    })
+    it("converts null results from the connection", async () => {
+      spyOn(connection, "prepareCallHierarchy").and.resolveTo(null)
+      const result = <any>(
+        await new CallHierarchyAdapter().getCallHierarchy(connection, fakeEditor, new Point(0, 0), "outgoing")
+      )
+      expect(result.type).toEqual("outgoing")
+      expect(result.data).toEqual([])
+    })
+    it("converts empty results from the connection", async () => {
+      spyOn(connection, "prepareCallHierarchy").and.resolveTo([])
+      const result = <any>(
+        await new CallHierarchyAdapter().getCallHierarchy(connection, fakeEditor, new Point(0, 0), "outgoing")
+      )
+      expect(result.type).toEqual("outgoing")
+      expect(result.data).toEqual([])
+    })
+    it("returns itemAt for incoming requests", async () => {
+      spyOn(connection, "prepareCallHierarchy").and.resolveTo([callHierarchyItem])
+      spyOn(connection, "callHierarchyIncomingCalls").and.resolveTo([
+        {
+          from: callHierarchyItem,
+          fromRanges: [],
+        },
+      ])
+      const result = <any>(
+        await new CallHierarchyAdapter().getCallHierarchy(connection, fakeEditor, new Point(0, 0), "incoming")
+      )
+      expect((await result.itemAt(0)).type).toEqual("incoming")
+      expect((await result.itemAt(0)).data).toEqual([
+        {
+          path: "C:\\path\\to\\file.ts",
+          name: "hello",
+          icon: "type-function",
+          tags: [],
+          detail: "",
+          range: new Range([0, 0], [1, 1]),
+          selectionRange: new Range([0, 24], [0, 29]),
+          rawData: jasmine.anything(),
+        },
+      ])
+      expect((await (await result.itemAt(0)).itemAt(0)).type).toEqual("incoming")
+      expect((await (await result.itemAt(0)).itemAt(0)).data).toEqual([
+        {
+          path: "C:\\path\\to\\file.ts",
+          name: "hello",
+          icon: "type-function",
+          tags: [],
+          detail: "",
+          range: new Range([0, 0], [1, 1]),
+          selectionRange: new Range([0, 24], [0, 29]),
+          rawData: jasmine.anything(),
+        },
+      ])
+    })
+    it("returns itemAt for outgoing requests", async () => {
+      spyOn(connection, "prepareCallHierarchy").and.resolveTo([callHierarchyItem])
+      spyOn(connection, "callHierarchyOutgoingCalls").and.resolveTo([
+        {
+          to: callHierarchyItem,
+          fromRanges: [],
+        },
+      ])
+      const result = <any>(
+        await new CallHierarchyAdapter().getCallHierarchy(connection, fakeEditor, new Point(0, 0), "outgoing")
+      )
+      expect((await result.itemAt(0)).type).toEqual("outgoing")
+      expect((await result.itemAt(0)).data).toEqual([
+        {
+          path: "C:\\path\\to\\file.ts",
+          name: "hello",
+          icon: "type-function",
+          tags: [],
+          detail: "",
+          range: new Range([0, 0], [1, 1]),
+          selectionRange: new Range([0, 24], [0, 29]),
+          rawData: jasmine.anything(),
+        },
+      ])
+      expect((await (await result.itemAt(0)).itemAt(0)).type).toEqual("outgoing")
+      expect((await (await result.itemAt(0)).itemAt(0)).data).toEqual([
+        {
+          path: "C:\\path\\to\\file.ts",
+          name: "hello",
+          icon: "type-function",
+          tags: [],
+          detail: "",
+          range: new Range([0, 0], [1, 1]),
+          selectionRange: new Range([0, 24], [0, 29]),
+          rawData: jasmine.anything(),
+        },
+      ])
+    })
+  })
+
+  describe("getIncoming", () => {
+    it("converts the results from the connection", async () => {
+      spyOn(connection, "callHierarchyIncomingCalls").and.resolveTo([
+        {
+          from: callHierarchyItem,
+          fromRanges: [],
+        },
+      ])
+      const result = <any>await new CallHierarchyAdapter().getIncoming(connection, callHierarchyItem)
+      expect(result.type).toEqual("incoming")
+      expect(result.data).toEqual([
+        {
+          path: "C:\\path\\to\\file.ts",
+          name: "hello",
+          icon: "type-function",
+          tags: [],
+          detail: "",
+          range: new Range([0, 0], [1, 1]),
+          selectionRange: new Range([0, 24], [0, 29]),
+          rawData: jasmine.anything(),
+        },
+      ])
+    })
+    it("converts null results from the connection", async () => {
+      spyOn(connection, "callHierarchyIncomingCalls").and.resolveTo(null)
+      const result = <any>await new CallHierarchyAdapter().getIncoming(connection, callHierarchyItem)
+      expect(result.type).toEqual("incoming")
+      expect(result.data).toEqual([])
+    })
+    it("converts empty results from the connection", async () => {
+      spyOn(connection, "callHierarchyIncomingCalls").and.resolveTo([])
+      const result = <any>await new CallHierarchyAdapter().getIncoming(connection, callHierarchyItem)
+      expect(result.type).toEqual("incoming")
+      expect(result.data).toEqual([])
+    })
+  })
+
+  describe("getOutgoing", () => {
+    it("converts the results from the connection", async () => {
+      spyOn(connection, "callHierarchyOutgoingCalls").and.resolveTo([
+        {
+          to: callHierarchyItem,
+          fromRanges: [],
+        },
+      ])
+      const result = <any>await new CallHierarchyAdapter().getOutgoing(connection, callHierarchyItem)
+      expect(result.type).toEqual("outgoing")
+      expect(result.data).toEqual([
+        {
+          path: "C:\\path\\to\\file.ts",
+          name: "hello",
+          icon: "type-function",
+          tags: [],
+          detail: "",
+          range: new Range([0, 0], [1, 1]),
+          selectionRange: new Range([0, 24], [0, 29]),
+          rawData: jasmine.anything(),
+        },
+      ])
+    })
+    it("converts null results from the connection", async () => {
+      spyOn(connection, "callHierarchyOutgoingCalls").and.resolveTo(null)
+      const result = <any>await new CallHierarchyAdapter().getOutgoing(connection, callHierarchyItem)
+      expect(result.type).toEqual("outgoing")
+      expect(result.data).toEqual([])
+    })
+    it("converts empty results from the connection", async () => {
+      spyOn(connection, "callHierarchyOutgoingCalls").and.resolveTo([])
+      const result = <any>await new CallHierarchyAdapter().getOutgoing(connection, callHierarchyItem)
+      expect(result.type).toEqual("outgoing")
+      expect(result.data).toEqual([])
+    })
+  })
+})

--- a/test/languageclient.test.ts
+++ b/test/languageclient.test.ts
@@ -241,6 +241,54 @@ describe("LanguageClientConnection", () => {
       expect(lc._sendRequest.calls.argsFor(0)[0].method).toBe("textDocument/rename")
       expect(lc._sendRequest.calls.argsFor(0)[1]).toBe(params)
     })
+
+    it("sends a request for prepareCallHierarchy", async () => {
+      const params: ls.CallHierarchyPrepareParams = {
+        textDocument: { uri: "file:///a/b.txt" },
+        position: { line: 1, character: 2 },
+      }
+      await lc.prepareCallHierarchy(params)
+
+      expect(lc._sendRequest).toHaveBeenCalled()
+      expect(lc._sendRequest.calls.argsFor(0)[0].method).toBe("textDocument/prepareCallHierarchy")
+      expect(lc._sendRequest.calls.argsFor(0)[1]).toBe(params)
+    })
+
+    it("sends a request for callHierarchyIncomingCalls", async () => {
+      const params: ls.CallHierarchyIncomingCallsParams = {
+        item: {
+          name: "hello",
+          kind: 12,
+          detail: "",
+          uri: "file:///C:/path/to/file.ts",
+          range: { start: { line: 0, character: 0 }, end: { line: 1, character: 1 } },
+          selectionRange: { start: { line: 0, character: 24 }, end: { line: 0, character: 29 } },
+        },
+      }
+      await lc.callHierarchyIncomingCalls(params)
+
+      expect(lc._sendRequest).toHaveBeenCalled()
+      expect(lc._sendRequest.calls.argsFor(0)[0].method).toBe("callHierarchy/incomingCalls")
+      expect(lc._sendRequest.calls.argsFor(0)[1]).toBe(params)
+    })
+
+    it("sends a request for callHierarchyOutgoingCalls", async () => {
+      const params: ls.CallHierarchyOutgoingCallsParams = {
+        item: {
+          name: "hello",
+          kind: 12,
+          detail: "",
+          uri: "file:///C:/path/to/file.ts",
+          range: { start: { line: 0, character: 0 }, end: { line: 1, character: 1 } },
+          selectionRange: { start: { line: 0, character: 24 }, end: { line: 0, character: 29 } },
+        },
+      }
+      await lc.callHierarchyOutgoingCalls(params)
+
+      expect(lc._sendRequest).toHaveBeenCalled()
+      expect(lc._sendRequest.calls.argsFor(0)[0].method).toBe("callHierarchy/outgoingCalls")
+      expect(lc._sendRequest.calls.argsFor(0)[1]).toBe(params)
+    })
   })
 
   describe("send notifications", () => {


### PR DESCRIPTION
This is needed for https://github.com/atom-community/atom-ide-outline/pull/131.

Originally the provider was implemented in atom-ide-deno, but I'll port that code to here. ([link1](https://github.com/ayame113/atom-ide-deno/blob/b2750d139083b99d3db9bad95d0f1eff84d07f22/lib/adapters/call-hierarchy-adapter.ts), [link2](https://github.com/ayame113/atom-ide-deno/blob/f471c2f7b6e1057c8ead0162cacaffa968e742f2/lib/main.ts#L252))
