### PR TITLE
fix(convert/pathToUri): Improve the encoding of non-alphanumeric paths other than the file protocol

### DIFF
--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -17,6 +17,9 @@ export default class Convert {
    * @returns The Uri corresponding to the path. e.g. file:///a/b/c.txt
    */
   public static pathToUri(filePath: string): string {
+    if (new URL(filePath, "file://").protocol !== "file:") {
+      return filePath
+    }
     let newPath = filePath.replace(/\\/g, "/")
     if (newPath[0] !== "/") {
       newPath = `/${newPath}`

--- a/test/convert.test.ts
+++ b/test/convert.test.ts
@@ -50,6 +50,7 @@ describe("Convert", () => {
     })
 
     it("does not encode Windows drive specifiers", () => {
+      setProcessPlatform("win32")
       expect(Convert.pathToUri("d:\\ee\\ff.txt")).toBe("file:///d:/ee/ff.txt")
     })
 

--- a/test/convert.test.ts
+++ b/test/convert.test.ts
@@ -52,9 +52,10 @@ describe("Convert", () => {
     it("does not encode Windows drive specifiers", () => {
       // This test only succeeds on windows. (Because of the difference in the processing method of drive characters)
       // However, it is enough to test the windows drive character only on windows.
-      if (process.platform === "win32") {
-        expect(Convert.pathToUri("d:\\ee\\ff.txt")).toBe("file:///d:/ee/ff.txt")
+      if (process.platform !== "win32") {
+        pending("Only test on windows")
       }
+      expect(Convert.pathToUri("d:\\ee\\ff.txt")).toBe("file:///d:/ee/ff.txt")
     })
 
     it("URI encodes special characters", () => {

--- a/test/convert.test.ts
+++ b/test/convert.test.ts
@@ -50,8 +50,11 @@ describe("Convert", () => {
     })
 
     it("does not encode Windows drive specifiers", () => {
-      setProcessPlatform("win32")
-      expect(Convert.pathToUri("d:\\ee\\ff.txt")).toBe("file:///d:/ee/ff.txt")
+      // This test only succeeds on windows. (Because of the difference in the processing method of drive characters)
+      // However, it is enough to test the windows drive character only on windows.
+      if (process.platform === "win32") {
+        expect(Convert.pathToUri("d:\\ee\\ff.txt")).toBe("file:///d:/ee/ff.txt")
+      }
     })
 
     it("URI encodes special characters", () => {

--- a/test/convert.test.ts
+++ b/test/convert.test.ts
@@ -25,6 +25,18 @@ describe("Convert", () => {
   })
 
   describe("pathToUri", () => {
+    it("does not convert path other than file:", () => {
+      expect(Convert.pathToUri("http://atom.io/a")).toBe("http://atom.io/a")
+      expect(Convert.pathToUri("https://atom.io/b")).toBe("https://atom.io/b")
+      expect(Convert.pathToUri("deno:/hello.js")).toBe("deno:/hello.js")
+    })
+
+    it("does not convert non-alphanumeric path other than file:", () => {
+      expect(Convert.pathToUri("http://atom.io/a%40%E3%81%82")).toBe("http://atom.io/a%40%E3%81%82")
+      expect(Convert.pathToUri("https://atom.io/b?foo=bar")).toBe("https://atom.io/b?foo=bar")
+      expect(Convert.pathToUri("deno:/hello%40%E3%81%82.js")).toBe("deno:/hello%40%E3%81%82.js")
+    })
+
     it("prefixes an absolute path with file://", () => {
       expect(Convert.pathToUri("/a/b/c/d.txt")).toBe("file:///a/b/c/d.txt")
     })
@@ -47,10 +59,18 @@ describe("Convert", () => {
   })
 
   describe("uriToPath", () => {
-    it("does not convert http: and https: uri's", () => {
+    it("does not convert uri other than file:", () => {
       setProcessPlatform("darwin")
       expect(Convert.uriToPath("http://atom.io/a")).toBe("http://atom.io/a")
       expect(Convert.uriToPath("https://atom.io/b")).toBe("https://atom.io/b")
+      expect(Convert.uriToPath("deno:/hello.js")).toBe("deno:/hello.js")
+    })
+
+    it("does not convert non-alphanumeric uri other than file:", () => {
+      setProcessPlatform("darwin")
+      expect(Convert.uriToPath("http://atom.io/a%40%E3%81%82")).toBe("http://atom.io/a%40%E3%81%82")
+      expect(Convert.uriToPath("https://atom.io/b?foo=bar")).toBe("https://atom.io/b?foo=bar")
+      expect(Convert.uriToPath("deno:/hello%40%E3%81%82.js")).toBe("deno:/hello%40%E3%81%82.js")
     })
 
     it("converts a file:// path to an absolute path", () => {


### PR DESCRIPTION
resolve ayame113/atom-ide-deno#74

There is a difference in the conversion process between `Convert.uriToPath` and `Convert.pathToUri`.

|function|(arguments -> retuen value)|
|---|---|
|`uriToPath()`|`https://foo.bar/%40`->`https://foo.bar/%40`<br>`https://foo.bar/%2540`->`https://foo.bar/%2540`|
|`pathToUri()`|`https://foo.bar/%40`->`https://foo.bar/%2540`|

The decoding process of urls other than file: was changed by https://github.com/atom-community/atom-languageclient/commit/6f1e149c052888ff00c26b79be66e7bc7109d84f, but it seems that the encoding process was not changed.
This PR modifies the encoding process for paths other than file: .